### PR TITLE
Add vpn_quota_connections metric

### DIFF
--- a/solace_prometheus_exporter.go
+++ b/solace_prometheus_exporter.go
@@ -140,7 +140,7 @@ var metricDesc = map[string]Metrics{
 		"vpn_total_remote_unique_subscriptions": prometheus.NewDesc(namespace+"_"+"vpn_total_remote_unique_subscriptions", "total unique remote subscriptions count", variableLabelsVpn, nil),
 		"vpn_total_unique_subscriptions":        prometheus.NewDesc(namespace+"_"+"vpn_total_unique_subscriptions", "total unique subscriptions count", variableLabelsVpn, nil),
 		"vpn_connections":                       prometheus.NewDesc(namespace+"_"+"vpn_connections", "Number of connections.", variableLabelsVpn, nil),
-		"vpn_max_connections":                   prometheus.NewDesc(namespace+"_"+"vpn_max_connections", "Maximum number of connections.", variableLabelsVpn, nil),
+		"vpn_quota_connections":                 prometheus.NewDesc(namespace+"_"+"vpn_quota_connections", "Maximum number of connections.", variableLabelsVpn, nil),
 	},
 	"VpnReplication": {
 		"vpn_replication_admin_state":                  prometheus.NewDesc(namespace+"_"+"vpn_replication_admin_state", "Replication Admin Status (0-shutdown, 1-enabled, 2-n/a)", variableLabelsVpn, nil),
@@ -638,7 +638,7 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric, vpnFilter string) (o
 						TotalRemoteUniqueSubscriptions float64 `xml:"total-remote-unique-subscriptions"`
 						TotalUniqueSubscriptions       float64 `xml:"total-unique-subscriptions"`
 						Connections                    float64 `xml:"connections"`
-						MaxConnections                 float64 `xml:"max-connections"`
+						QuotaConnections               float64 `xml:"max-connections"`
 					} `xml:"vpn"`
 				} `xml:"message-vpn"`
 			} `xml:"show"`
@@ -678,7 +678,7 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric, vpnFilter string) (o
 		ch <- prometheus.MustNewConstMetric(metricDesc["Vpn"]["vpn_total_remote_unique_subscriptions"], prometheus.GaugeValue, vpn.TotalRemoteUniqueSubscriptions, vpn.Name)
 		ch <- prometheus.MustNewConstMetric(metricDesc["Vpn"]["vpn_total_unique_subscriptions"], prometheus.GaugeValue, vpn.TotalUniqueSubscriptions, vpn.Name)
 		ch <- prometheus.MustNewConstMetric(metricDesc["Vpn"]["vpn_connections"], prometheus.GaugeValue, vpn.Connections, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricDesc["Vpn"]["vpn_max_connections"], prometheus.GaugeValue, vpn.MaxConnections, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricDesc["Vpn"]["vpn_quota_connections"], prometheus.GaugeValue, vpn.QuotaConnections, vpn.Name)
 	}
 
 	return 1, nil


### PR DESCRIPTION
To be able to alert on thresholds for too many connections, it is necessary to not only have the `vpn_connections` metric, but also the maximum. Luckily the SEMP request for VPNs already returns something like `<max-connections>1000</max-connections>`.

This PR extends the exporter by a new metric `vpn_max_connections`