### PR TITLE
Feature add spoolfile usage

### DIFF
--- a/semp/metricDesc.go
+++ b/semp/metricDesc.go
@@ -90,6 +90,7 @@ var MetricDesc = map[string]Metrics{
 		"system_spool_disk_partition_usage_active_percent": prometheus.NewDesc(namespace+"_"+"system_spool_disk_partition_usage_active_percent", "Total disk usage in percent.", nil, nil),
 		"system_spool_usage_bytes":                         prometheus.NewDesc(namespace+"_"+"system_spool_usage_bytes", "Spool total persisted usage.", nil, nil),
 		"system_spool_usage_msgs":                          prometheus.NewDesc(namespace+"_"+"system_spool_usage_msgs", "Spool total number of persisted messages.", nil, nil),
+		"system_spool_files_utilization_percent":           prometheus.NewDesc(namespace+"_"+"system_spool_files_utilization_percent", "Utilization of spool files in percent.", nil, nil),
 	},
 	"Redundancy": {
 		"system_redundancy_up":           prometheus.NewDesc(namespace+"_"+"system_redundancy_up", "Is redundancy up? (0=Down, 1=Up).", variableLabelsRedundancy, nil),


### PR DESCRIPTION
In order to be able to monitor spool file fragmentation and the thresholds used by the automatic defrag jobs, we'd like to add the `spool-files-utilization-percentage` metic to the exporter.

![image](https://user-images.githubusercontent.com/80671695/193221233-e84686fa-b548-416a-96fa-345173d2f140.png)

This PR adds the following new metric:
```
# HELP solace_system_spool_files_utilization_percent Utilization of spool files in percent.
# TYPE solace_system_spool_files_utilization_percent gauge
solace_system_spool_files_utilization_percent 1.96
```

Also I've refactored the parsing and assignment for float values with potential "-"'s just a little bit to not clutter the function context with `err1-err99` instances but keep them in local context of the `if`statement.