### PR TITLE
Pkcs12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ solace_prometheus_exporter
 .idea
 *.iml
 *.pem
+*.p12

--- a/exporter/tlsServer.go
+++ b/exporter/tlsServer.go
@@ -1,0 +1,83 @@
+package exporter
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/promlog"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+func ListenAndServeTLS(conf Config) {
+
+	promlogConfig := promlog.Config{
+		Level:  &promlog.AllowedLevel{},
+		Format: &promlog.AllowedFormat{},
+	}
+	promlogConfig.Level.Set("info")
+	promlogConfig.Format.Set("logfmt")
+
+	logger := promlog.New(&promlogConfig)
+
+	var tlsCert tls.Certificate
+
+	if strings.ToUpper(conf.CertType) == CERTTYPE_PKCS12 {
+
+		// Read byte data from pkcs12 keystore
+		p12_data, err := os.ReadFile(conf.Pkcs12File)
+		if err != nil {
+			level.Error(logger).Log("Error reading PKCS12 file", err)
+			return
+		}
+
+		// Extract cert and key from pkcs12 keystore
+		privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(p12_data, conf.Pkcs12Pass)
+		if err != nil {
+			level.Error(logger).Log("PKCS12 - Error decoding chain", err)
+			return
+		}
+
+		certBytes := [][]byte{leafCert.Raw}
+		for _, ca := range caCerts {
+			certBytes = append(certBytes, ca.Raw)
+		}
+		tlsCert = tls.Certificate{
+			Certificate: certBytes,
+			PrivateKey:  privateKey,
+		}
+	} else {
+		var err error
+		tlsCert, err = tls.LoadX509KeyPair(conf.Certificate, conf.PrivateKey)
+		if err != nil {
+			level.Error(logger).Log("PEM - Error loading keypair", err)
+			return
+		}
+	}
+
+	cfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+		Certificates: []tls.Certificate{tlsCert},
+	}
+	http := &http.Server{
+		Addr:         conf.ListenAddr,
+		TLSConfig:    cfg,
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+	}
+
+	if err := http.ListenAndServeTLS("", ""); err != nil {
+		level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
+		os.Exit(2)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	gopkg.in/ini.v1 v1.67.0
 )
 
+require golang.org/x/crypto v0.11.0 // indirect
+
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 // indirect
@@ -24,4 +26,5 @@ require (
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
+golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
@@ -63,3 +65,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/solace_prometheus_exporter.go
+++ b/solace_prometheus_exporter.go
@@ -14,7 +14,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"net/http"
 	"os"
 	"solace_exporter/exporter"
@@ -30,7 +29,6 @@ import (
 	"github.com/prometheus/common/promlog/flag"
 	promVersion "github.com/prometheus/common/version"
 	"golang.org/x/sync/semaphore"
-	"software.sslmate.com/src/go-pkcs12"
 )
 
 const version = float64(1004005)
@@ -245,62 +243,7 @@ func main() {
 
 	// start server
 	if conf.EnableTLS {
-		var tlsCert tls.Certificate
-		if strings.ToUpper(conf.CertType) == exporter.CERTTYPE_PKCS12 {
-
-			// Read byte data from pkcs12 keystore
-			p12_data, err := os.ReadFile(conf.Pkcs12File)
-			if err != nil {
-				level.Error(logger).Log("Error reading PKCS12 file", err)
-				return
-			}
-
-			// Extract cert and key from pkcs12 keystore
-			privateKey, leafCert, caCerts, err := pkcs12.DecodeChain(p12_data, conf.Pkcs12Pass)
-			if err != nil {
-				level.Error(logger).Log("PKCS12 - Error decoding chain", err)
-				return
-			}
-
-			certBytes := [][]byte{leafCert.Raw}
-			for _, ca := range caCerts {
-				certBytes = append(certBytes, ca.Raw)
-			}
-			tlsCert = tls.Certificate{
-				Certificate: certBytes,
-				PrivateKey:  privateKey,
-			}
-		} else {
-			tlsCert, err = tls.LoadX509KeyPair(conf.Certificate, conf.PrivateKey)
-			if err != nil {
-				level.Error(logger).Log("PEM - Error loading keypair", err)
-				return
-			}
-		}
-
-		cfg := &tls.Config{
-			MinVersion:               tls.VersionTLS12,
-			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-			PreferServerCipherSuites: true,
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			},
-			Certificates: []tls.Certificate{tlsCert},
-		}
-		http := &http.Server{
-			Addr:         conf.ListenAddr,
-			TLSConfig:    cfg,
-			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
-		}
-
-		if err := http.ListenAndServeTLS("", ""); err != nil {
-			level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
-			os.Exit(2)
-		}
-
+		exporter.ListenAndServeTLS(*conf)
 	} else {
 		if err := http.ListenAndServe(conf.ListenAddr, nil); err != nil {
 			level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)

--- a/solace_prometheus_exporter.ini
+++ b/solace_prometheus_exporter.ini
@@ -2,7 +2,7 @@
 # Address to listen on for web interface and telemetry.
 listenAddr=0.0.0.0:9628
 
-# Enable TLS on listenAddr endpoint. Make sure to provide certificate and private key files.
+# Enable TLS on listenAddr endpoint. Make sure to provide certificate and private key files when using certType=PEM or or PKCS12 file and password when using PKCS12.
 # can be overridden via env varibale SOLACE_LISTEN_TLS or via cli parameter --enable-tls
 enableTLS=false
 
@@ -13,6 +13,18 @@ certificate=cert.pem
 # Path to the private key pem file
 # can be overridden via env varibale SOLACE_PRIVATE_KEY or via cli parameter --private-key=key.pem
 privateKey=key.pem
+
+# Set the certificate type PEM | PKCS12. Make sure to provide certificate and private key files for PEM or PKCS12 file and password.
+# can be overridden via env varibale SOLACE_LISTEN_CERTTYPE or via cli parameter --cert-type
+certType=PEM
+
+# Path to the server certificate (including intermediates and CA's certificate)
+# can be overridden via env varibale SOLACE_PKCS12_FILE or via cli parameter --pkcs12File=keystore.p12
+pkcs12File=keystore.p12
+
+# Password to decrypt PKCS12 file.
+# can be overridden via env varibale SOLACE_PKCS12_PASS or via cli parameter --pkcs12Pass=passwordHere
+pkcs12Pass=123456
 
 # Base URI on which to scrape Solace broker.
 scrapeUri=https://mr-connection-j6em7yuyi7k.messaging.solace.cloud:943

--- a/solace_prometheus_exporter.ini
+++ b/solace_prometheus_exporter.ini
@@ -3,27 +3,27 @@
 listenAddr=0.0.0.0:9628
 
 # Enable TLS on listenAddr endpoint. Make sure to provide certificate and private key files when using certType=PEM or or PKCS12 file and password when using PKCS12.
-# can be overridden via env varibale SOLACE_LISTEN_TLS or via cli parameter --enable-tls
+# can be overridden via env variable SOLACE_LISTEN_TLS or via cli parameter --enable-tls
 enableTLS=false
 
 # Path to the server certificate (including intermediates and CA's certificate)
-# can be overridden via env varibale SOLACE_SERVER_CERT or via cli parameter --certificate=cert.pem
+# can be overridden via env variable SOLACE_SERVER_CERT or via cli parameter --certificate=cert.pem
 certificate=cert.pem
 
 # Path to the private key pem file
-# can be overridden via env varibale SOLACE_PRIVATE_KEY or via cli parameter --private-key=key.pem
+# can be overridden via env variable SOLACE_PRIVATE_KEY or via cli parameter --private-key=key.pem
 privateKey=key.pem
 
 # Set the certificate type PEM | PKCS12. Make sure to provide certificate and private key files for PEM or PKCS12 file and password.
-# can be overridden via env varibale SOLACE_LISTEN_CERTTYPE or via cli parameter --cert-type
+# can be overridden via env variable SOLACE_LISTEN_CERTTYPE or via cli parameter --cert-type
 certType=PEM
 
 # Path to the server certificate (including intermediates and CA's certificate)
-# can be overridden via env varibale SOLACE_PKCS12_FILE or via cli parameter --pkcs12File=keystore.p12
+# can be overridden via env variable SOLACE_PKCS12_FILE or via cli parameter --pkcs12File=keystore.p12
 pkcs12File=keystore.p12
 
 # Password to decrypt PKCS12 file.
-# can be overridden via env varibale SOLACE_PKCS12_PASS or via cli parameter --pkcs12Pass=passwordHere
+# can be overridden via env variable SOLACE_PKCS12_PASS or via cli parameter --pkcs12Pass=passwordHere
 pkcs12Pass=123456
 
 # Base URI on which to scrape Solace broker.


### PR DESCRIPTION
Our SCEP client provisions keystores in .p12 / pkcs12 format.
With this demand I've added the support for pkcs12 decoding and using it for ListenAndServeTLS (net/http).

To avoid a breaking change, "certType" will be set to PEM if the new parameter is not configured. This will ensure that the exporter will remain working for users with existing configuration and new release/build.
-> exporter/config.struct.go line 77-81