### PR TITLE
Hardware specific targets and other minor modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ solace_prometheus_exporter
 *.iml
 *.pem
 *.p12
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ not starting with the word "internal"
 | TopicEndpointStats                    | yes                 | yes                   | no                       | may harm broker if many topic-endpoint                                | show topic-endpoint itemFilter message-vpn vpnFilter rates count 100 (paged)  | software, appliance |
 | TopicEndpointDetails                  | yes                 | yes                   | no                       | may harm broker if many topic-endpoints                               | show topic-endpoint itemFilter message-vpn vpnFilter detail count 100 (paged) | software, appliance |
 | ClusterLinks                          | yes                 | yes                   | no                       | dont harm broker                                                      | show the state of the cluster links. Filters are for clusterName and linkName | software, appliance |
+| Alarm                                 | no                  | no                    | no                       | dont harm broker                                                      | show alarm                                                                    | appliance           |
+| BridgeRemote                          | yes                 | yes                   | no                       | dont harm broker                                                      | show bridge itemFilter message-vpn vpnFilter                                  | software, appliance |
+| Environment                           | yes                 | no                    | no                       | dont harm broker                                                      | show environment                                                              | appliance           |
+| Hardware                              | no                  | no                    | no                       | dont harm broker                                                      | show hardware                                                                 | appliance           |
+| InterfaceHW                           | no                  | yes                   | no                       | dont harm broker                                                      | show interface interfaceFilter                                                | appliance           |
+| Raid                                  | no                  | no                    | no                       | dont harm broker                                                      | show disk                                                                     | appliance           |
 
 ##### V2 endpoints
 
@@ -307,6 +313,9 @@ timeout = 5s
 # Flag that enables SSL certificate verification for the scrape URI.
 sslVerify = false
 
+# Flag that enables HW Broker specific targets and disables SW specific ones.
+isHWBroker=false
+
 # Flag that enables Usage of the operating system proxy configuration.
 # false=No proxy will be used at all.
 useSystemProxy = false
@@ -327,6 +336,7 @@ Sample environment variables:
 ```bash
 SOLACE_LISTEN_ADDR=0.0.0.0:9628
 SOLACE_LISTEN_TLS=true
+SOLACE_IS_HW_BROKER=false
 SOLACE_SERVER_CERT=/path/to/your/cert.pem
 SOLACE_PRIVATE_KEY=/path/to/your/key.pem
 SOLACE_LISTEN_CERTTYPE=PEM

--- a/docker/solace_prometheus_exporter.ini
+++ b/docker/solace_prometheus_exporter.ini
@@ -17,6 +17,9 @@ timeout=5s
 # Flag that enables SSL certificate verification for the scrape URI.
 sslVerify=false
 
+# Flag that enables HW Broker specific targets and disables SW specific ones.
+isHWBroker=false
+
 [endpoint.solace-std]
 Version=*|*
 Health=*|*

--- a/exporter/config.struct.go
+++ b/exporter/config.struct.go
@@ -33,6 +33,7 @@ type Config struct {
 	PrefetchInterval        time.Duration
 	ParallelSempConnections int64
 	logBrokerToSlowWarnings bool
+	IsHWBroker              bool
 }
 
 const (
@@ -128,6 +129,10 @@ func ParseConfig(configFile string) (map[string][]DataSource, *Config, error) {
 		return nil, nil, err
 	}
 	conf.logBrokerToSlowWarnings, err = parseConfigBoolOptional(cfg, "solace", "logBrokerToSlowWarnings", "SOLACE_LOG_BROKER_IS_SLOW_WARNING", true)
+	if err != nil {
+		return nil, nil, err
+	}
+	conf.IsHWBroker, err = parseConfigBoolOptional(cfg, "solace", "isHWBroker", "SOLACE_IS_HW_BROKER", false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/exporter/exporter.collect.go
+++ b/exporter/exporter.collect.go
@@ -21,15 +21,49 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 		case "Version", "VersionV1":
 			up, err = e.semp.GetVersionSemp1(ch)
 		case "Health", "HealthV1":
-			up, err = e.semp.GetHealthSemp1(ch)
+			if !e.config.IsHWBroker {
+				up, err = e.semp.GetHealthSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Software only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
 		case "StorageElement", "StorageElementV1":
-			up, err = e.semp.GetStorageElementSemp1(ch, dataSource.ItemFilter)
+			if !e.config.IsHWBroker {
+				up, err = e.semp.GetStorageElementSemp1(ch, dataSource.ItemFilter)
+			} else {
+				up = 0
+				err = errors.New("Software only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
 		case "Disk", "DiskV1":
-			up, err = e.semp.GetDiskSemp1(ch)
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetDiskSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
+		case "Raid", "RaidV1":
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetRaidSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
 		case "Memory", "MemoryV1":
 			up, err = e.semp.GetMemorySemp1(ch)
 		case "Interface", "InterfaceV1":
 			up, err = e.semp.GetInterfaceSemp1(ch, dataSource.ItemFilter)
+		case "InterfaceHW", "InterfaceHWV1":
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetInterfaceHWSemp1(ch, dataSource.ItemFilter)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
 		case "GlobalStats", "GlobalStatsV1":
 			up, err = e.semp.GetGlobalStatsSemp1(ch)
 		case "GlobalSystemInfo", "GlobalSystemInfoV1":
@@ -38,6 +72,30 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 			up, err = e.semp.GetSpoolSemp1(ch)
 		case "Redundancy", "RedundancyV1":
 			up, err = e.semp.GetRedundancySemp1(ch)
+		case "Alarm", "AlarmV1":
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetAlarmSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
+		case "Environment", "EnvironmentV1":
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetEnvironmentSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
+		case "Hardware", "HardwareV1":
+			if e.config.IsHWBroker {
+				up, err = e.semp.GetHardwareSemp1(ch)
+			} else {
+				up = 0
+				err = errors.New("Hardware only scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+				_ = level.Error(e.logger).Log("Hardware only  scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")
+			}
 		case "ReplicationStats", "ReplicationStatsV1":
 			up, err = e.semp.GetReplicationStatsSemp1(ch)
 		case "ConfigSyncRouter", "ConfigSyncRouterV1":
@@ -52,6 +110,8 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 			up, err = e.semp.GetConfigSyncVpnSemp1(ch, dataSource.VpnFilter)
 		case "Bridge", "BridgeV1":
 			up, err = e.semp.GetBridgeSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
+		case "BridgeRemote", "BridgeRemoteV1":
+			up, err = e.semp.GetBridgeRemoteSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
 		case "VpnSpool", "VpnSpoolV1":
 			up, err = e.semp.GetVpnSpoolSemp1(ch, dataSource.VpnFilter)
 		case "Client", "ClientV1":
@@ -66,7 +126,6 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 			up, err = e.semp.GetClientMessageSpoolStatsSemp1(ch, dataSource.VpnFilter)
 		case "ClusterLinks", "ClusterLinksV1":
 			up, err = e.semp.GetClusterLinksSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
-
 		case "VpnStats", "VpnStatsV1":
 			up, err = e.semp.GetVpnStatsSemp1(ch, dataSource.VpnFilter)
 		case "BridgeStats", "BridgeStatsV1":

--- a/exporter/exporter.struct.go
+++ b/exporter/exporter.struct.go
@@ -23,6 +23,6 @@ func NewExporter(logger log.Logger, conf *Config, dataSource *[]DataSource, vers
 		config:     conf,
 		dataSource: dataSource,
 		lastError:  nil,
-		semp:       semp.NewSemp(logger, conf.ScrapeURI, conf.newHttpClient(), conf.httpVisitor(), version, conf.logBrokerToSlowWarnings),
+		semp:       semp.NewSemp(logger, conf.ScrapeURI, conf.newHttpClient(), conf.httpVisitor(), version, conf.logBrokerToSlowWarnings, conf.IsHWBroker),
 	}
 }

--- a/semp/getAlarmSemp1.go
+++ b/semp/getAlarmSemp1.go
@@ -1,0 +1,54 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Get system Alarm information
+func (e *Semp) GetAlarmSemp1(ch chan<- PrometheusMetric) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Alarm struct {
+					Alarms struct {
+						Alarm []struct { // we don't need to parse out the values as we are just testing if an alarm is present
+						} `xml:"alarm"`
+					} `xml:"alarms"`
+				} `xml:"alarm"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><alarm/></show></rpc>"
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "AlarmSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape AlarmSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml AlarmSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+	var alarmsExist = false
+	// Check if an alarm is present
+	if len(target.RPC.Show.Alarm.Alarms.Alarm) != 0 {
+		alarmsExist = true
+	}
+	ch <- e.NewMetric(MetricDesc["Alarm"]["system_alarm"], prometheus.GaugeValue, encodeMetricBool(alarmsExist))
+
+	return 1, nil
+}

--- a/semp/getBridgeRemoteSemp1.go
+++ b/semp/getBridgeRemoteSemp1.go
@@ -1,0 +1,98 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Get status of bridges for all vpns
+// Same as GetBridge but adds labels for remote VPN and remote router
+func (e *Semp) GetBridgeRemoteSemp1(ch chan<- PrometheusMetric, vpnFilter string, itemFilter string) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Bridge struct {
+					Bridges struct {
+						NumTotalBridgesValue                 float64 `xml:"num-total-bridges"`
+						MaxNumTotalBridgesValue              float64 `xml:"max-num-total-bridges"`
+						NumLocalBridgesValue                 float64 `xml:"num-local-bridges"`
+						MaxNumLocalBridgesValue              float64 `xml:"max-num-local-bridges"`
+						NumRemoteBridgesValue                float64 `xml:"num-remote-bridges"`
+						MaxNumRemoteBridgesValue             float64 `xml:"max-num-remote-bridges"`
+						NumTotalRemoteBridgeSubscriptions    float64 `xml:"num-total-remote-bridge-subscriptions"`
+						MaxNumTotalRemoteBridgeSubscriptions float64 `xml:"max-num-total-remote-bridge-subscriptions"`
+						Bridge                               []struct {
+							BridgeName                      string  `xml:"bridge-name"`
+							LocalVpnName                    string  `xml:"local-vpn-name"`
+							ConnectedRemoteVpnName          string  `xml:"connected-remote-vpn-name"`
+							ConnectedRemoteRouterName       string  `xml:"connected-remote-router-name"`
+							AdminState                      string  `xml:"admin-state"`
+							ConnectionEstablisher           string  `xml:"connection-establisher"`
+							InboundOperationalState         string  `xml:"inbound-operational-state"`
+							InboundOperationalFailureReason string  `xml:"inbound-operational-failure-reason"`
+							OutboundOperationalState        string  `xml:"outbound-operational-state"`
+							QueueOperationalState           string  `xml:"queue-operational-state"`
+							Redundancy                      string  `xml:"redundancy"`
+							ConnectionUptimeInSeconds       float64 `xml:"connection-uptime-in-seconds"`
+						} `xml:"bridge"`
+					} `xml:"bridges"`
+				} `xml:"bridge"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><bridge><bridge-name-pattern>" + itemFilter + "</bridge-name-pattern><vpn-name-pattern>" + vpnFilter + "</vpn-name-pattern></bridge></show></rpc>"
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "BridgeRemoteSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape BridgeRemoteSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml BridgeRemoteSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_max_num_total_bridges"], prometheus.CounterValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumLocalBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_max_num_local_bridges"], prometheus.CounterValue, target.RPC.Show.Bridge.Bridges.MaxNumLocalBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumRemoteBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_max_num_remote_bridges"], prometheus.CounterValue, target.RPC.Show.Bridge.Bridges.MaxNumRemoteBridgesValue)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalRemoteBridgeSubscriptions)
+	ch <- e.NewMetric(MetricDesc["Bridge"]["bridges_max_num_total_remote_bridge_subscriptions"], prometheus.CounterValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalRemoteBridgeSubscriptions)
+	opStates := []string{"Init", "Shutdown", "NoShutdown", "Prepare", "Prepare-WaitToConnect",
+		"Prepare-FetchingDNS", "NotReady", "NotReady-Connecting", "NotReady-Handshaking", "NotReady-WaitNext",
+		"NotReady-WaitReuse", "NotRead-WaitBridgeVersionMismatch", "NotReady-WaitCleanup", "Ready", "Ready-Subscribing",
+		"Ready-InSync", "NotApplicable", "Invalid"}
+	failReasons := []string{"Bridge disabled", "No remote message-vpns configured", "SMF service is disabled", "Msg Backbone is disabled",
+		"Local message-vpn is disabled", "Active-Standby Role Mismatch", "Invalid Active-Standby Role", "Redundancy Disabled", "Not active",
+		"Replication standby", "Remote message-vpns disabled", "Enforce-trusted-common-name but empty trust-common-name list", "SSL transport used but cipher-suite list is empty", "Authentication Scheme is Client-Certificate but no certificate is configured",
+		"Client-Certificate Authentication Scheme used but not all Remote Message VPNs use SSL", "Basic Authentication Scheme used but Basic Client Username not configured", "Cluster Down", "Cluster Link Down", ""}
+	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
+		bridgeName := bridge.BridgeName
+		vpnName := bridge.LocalVpnName
+		remoteVpnName := bridge.ConnectedRemoteVpnName
+		remoteRouter := bridge.ConnectedRemoteRouterName
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_admin_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.AdminState, []string{"Enabled", "Disabled", "-", "N/A"}), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_connection_establisher"], prometheus.GaugeValue, encodeMetricMulti(bridge.ConnectionEstablisher, []string{"NotApplicable", "Local", "Remote", "Invalid"}), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_inbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalState, opStates), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_inbound_operational_failure_reason"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalFailureReason, failReasons), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_outbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.OutboundOperationalState, opStates), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_queue_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.QueueOperationalState, []string{"NotApplicable", "Bound", "Unbound"}), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_redundancy"], prometheus.GaugeValue, encodeMetricMulti(bridge.Redundancy, []string{"NotApplicable", "auto", "primary", "backup", "static", "none"}), vpnName, bridgeName, remoteVpnName, remoteRouter)
+		ch <- e.NewMetric(MetricDesc["BridgeRemote"]["bridge_connection_uptime_in_seconds"], prometheus.GaugeValue, bridge.ConnectionUptimeInSeconds, vpnName, bridgeName, remoteVpnName, remoteRouter)
+	}
+	return 1, nil
+}

--- a/semp/getEnvironmentSemp1.go
+++ b/semp/getEnvironmentSemp1.go
@@ -1,0 +1,96 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Get system Alarm information
+func (e *Semp) GetEnvironmentSemp1(ch chan<- PrometheusMetric) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Environment struct {
+					Mainboard struct {
+						Sensors struct {
+							Sensor []struct {
+								Type   string `xml:"type"`
+								Name   string `xml:"name"`
+								Value  string `xml:"value"`
+								Unit   string `xml:"unit"`
+								Status string `xml:"status"`
+							} `xml:"sensor"`
+						} `xml:"sensors"`
+					} `xml:"mainboard"`
+					Slots struct {
+						Slot []struct {
+							SlotNumber string `xml:"slot-number"`
+							CardType   string `xml:"card-type"`
+							Sensors    struct {
+								Sensor []struct {
+									Type   string `xml:"type"`
+									Name   string `xml:"name"`
+									Value  string `xml:"value"`
+									Unit   string `xml:"unit"`
+									Status string `xml:"status"`
+								} `xml:"sensor"`
+							} `xml:"sensors"`
+						} `xml:"slot"`
+					} `xml:"slots"`
+				} `xml:"environment"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><environment/></show></rpc>"
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "EnvironmentSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape EnvironmentSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml EnvironmentSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+
+	for _, sensor := range target.RPC.Show.Environment.Mainboard.Sensors.Sensor {
+		if sensor.Type == "Fan speed" && strings.Contains(sensor.Name, "Chassis") {
+			if value, err := strconv.ParseFloat(sensor.Value, 64); err == nil {
+				ch <- e.NewMetric(MetricDesc["Environment"]["system_chassis_fan_speed"], prometheus.GaugeValue, math.Round(value), sensor.Name)
+			}
+		} else if sensor.Type == "Temperature" && strings.Contains(sensor.Name, "Therm Margin") {
+			if value, err := strconv.ParseFloat(sensor.Value, 64); err == nil {
+				ch <- e.NewMetric(MetricDesc["Environment"]["system_cpu_thermal_margin"], prometheus.GaugeValue, math.Round(value), sensor.Name)
+			}
+		}
+	}
+	for _, slot := range target.RPC.Show.Environment.Slots.Slot {
+		if slot.CardType == "Network Acceleration Blade" {
+			for _, sensor := range slot.Sensors.Sensor {
+				if sensor.Type == "Temperature" && sensor.Name == "NPU Core Temp" {
+					if value, err := strconv.ParseFloat(sensor.Value, 64); err == nil {
+						ch <- e.NewMetric(MetricDesc["Environment"]["system_nab_core_temperature"], prometheus.GaugeValue, math.Round(value), sensor.Name)
+					}
+				}
+			}
+		}
+	}
+
+	return 1, nil
+}

--- a/semp/getEnvironmentSemp1.go
+++ b/semp/getEnvironmentSemp1.go
@@ -72,7 +72,7 @@ func (e *Semp) GetEnvironmentSemp1(ch chan<- PrometheusMetric) (ok float64, err 
 	for _, sensor := range target.RPC.Show.Environment.Mainboard.Sensors.Sensor {
 		if sensor.Type == "Fan speed" && strings.Contains(sensor.Name, "Chassis") {
 			if value, err := strconv.ParseFloat(sensor.Value, 64); err == nil {
-				ch <- e.NewMetric(MetricDesc["Environment"]["system_chassis_fan_speed"], prometheus.GaugeValue, math.Round(value), sensor.Name)
+				ch <- e.NewMetric(MetricDesc["Environment"]["system_chassis_fan_speed_rpm"], prometheus.GaugeValue, math.Round(value), sensor.Name)
 			}
 		} else if sensor.Type == "Temperature" && strings.Contains(sensor.Name, "Therm Margin") {
 			if value, err := strconv.ParseFloat(sensor.Value, 64); err == nil {

--- a/semp/getHardwareSemp1.go
+++ b/semp/getHardwareSemp1.go
@@ -1,0 +1,92 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"strings"
+)
+
+// Get system Alarm information
+func (e *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Hardware struct {
+					PowerRedundancy struct {
+						OperationalPowerSupplies float64 `xml:"operational-power-supplies"`
+					} `xml:"power-redundancy"`
+					Fabric struct {
+						Slot []struct {
+							SlotNumber       string `xml:"slot-number" optional:"yes"`
+							CardType         string `xml:"card-type" optional:"yes"`
+							OperationalState bool   `xml:"operational-state-up" optional:"yes"`
+							FlashCardState   string `xml:"flash-card-state" optional:"yes"`
+							PowerModuleState string `xml:"power-module-state" optional:"yes"`
+							MateLink1State   string `xml:"mate-link-1-state" optional:"yes"`
+							MateLink2State   string `xml:"mate-link-2-state" optional:"yes"`
+							FibreChannel     []struct {
+								Number           string `xml:"number"`
+								OperationalState string `xml:"operational-state"`
+								State            string `xml:"state"`
+							} `xml:"fibre-channel" optional:"yes"`
+							ExternalDiskLun []struct {
+								Number string `xml:"number"`
+								State  string `xml:"state"`
+							} `xml:"external-disk-lun" optional:"yes"`
+						} `xml:"slot"`
+					} `xml:"fabric"`
+				} `xml:"hardware"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><hardware><details/></hardware></show></rpc>"
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "HardwareSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape HardwareSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml HardwareSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+
+	ch <- e.NewMetric(MetricDesc["Hardware"]["operational_power_supplies"], prometheus.GaugeValue, target.RPC.Show.Hardware.PowerRedundancy.OperationalPowerSupplies)
+
+	for _, slot := range target.RPC.Show.Hardware.Fabric.Slot {
+		if slot.CardType == "Host Bus Adapter Blade" {
+			for _, FC := range slot.FibreChannel {
+				ch <- e.NewMetric(MetricDesc["Hardware"]["fibre_channel_operational_state"], prometheus.GaugeValue, encodeMetricMulti(FC.OperationalState, []string{"Linkdown", "Online"}), FC.Number)
+				ch <- e.NewMetric(MetricDesc["Hardware"]["fibre_channel_state"], prometheus.GaugeValue, encodeMetricMulti(FC.State, []string{"Link Down", "Link Up - F_Port (fabric via point-to-point)", "Link Up - Loop (private loop)"}), FC.Number)
+			}
+			for _, LUN := range slot.ExternalDiskLun {
+				State := "Ready"
+				if !strings.Contains(LUN.State, "Ready") {
+					State = "Offline"
+				}
+				ch <- e.NewMetric(MetricDesc["Hardware"]["external_disk_lun_state"], prometheus.GaugeValue, encodeMetricMulti(State, []string{"Offline", "Ready"}), LUN.Number)
+			}
+		} else if slot.CardType == "Assured Delivery Blade" {
+			ch <- e.NewMetric(MetricDesc["Hardware"]["adb_operational_state"], prometheus.GaugeValue, encodeMetricBool(slot.OperationalState))
+			ch <- e.NewMetric(MetricDesc["Hardware"]["adb_flash_card_state"], prometheus.GaugeValue, encodeMetricMulti(slot.FlashCardState, []string{"Link Down", "Ready"}))
+			ch <- e.NewMetric(MetricDesc["Hardware"]["adb_power_module_state"], prometheus.GaugeValue, encodeMetricMulti(slot.PowerModuleState, []string{"", "Ok"}))
+			ch <- e.NewMetric(MetricDesc["Hardware"]["adb_mate_link_port1_state"], prometheus.GaugeValue, encodeMetricMulti(slot.MateLink1State, []string{"LOS", "Ok", "No SFP Module", "No Data"}))
+			ch <- e.NewMetric(MetricDesc["Hardware"]["adb_mate_link_port2_state"], prometheus.GaugeValue, encodeMetricMulti(slot.MateLink2State, []string{"LOS", "Ok", "No SFP Module", "No Data"}))
+		}
+	}
+
+	return 1, nil
+}

--- a/semp/getInterfaceHWSemp1.go
+++ b/semp/getInterfaceHWSemp1.go
@@ -1,0 +1,96 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Get interface information
+func (e *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilter string) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Interface struct {
+					Interfaces struct {
+						Interface []struct {
+							Name    string `xml:"phy-interface"`
+							Enabled string `xml:"enabled"`
+							State   string `xml:"oper-status"`
+							Stats   struct {
+								RxPackets float64 `xml:"rx-pkts"`
+								RxBytes   float64 `xml:"rx-bytes"`
+								TxPackets float64 `xml:"tx-pkts"`
+								TxBytes   float64 `xml:"tx-bytes"`
+							} `xml:"stats"`
+							LAG struct {
+								ConfiguredMembers struct {
+									Member []struct {
+									} `xml:"member"`
+								} `xml:"configured-members"`
+								AvailableMembers struct {
+									Member []struct {
+									} `xml:"member"`
+								} `xml:"available-members"`
+								OperationalMembers struct {
+									Member []struct {
+									} `xml:"member"`
+								} `xml:"operational-members"`
+							} `xml:"lag" `
+							ETH struct {
+								LinkDetected string `xml:"link-detected" optional:"true" omitifempty:"true"`
+							} `xml:"eth"`
+						} `xml:"interface"`
+					} `xml:"interfaces"`
+				} `xml:"interface"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><interface>"
+	// * is an invalid HW interface filter, instead no filter shows all interfaces
+	if interfaceFilter != "*" {
+		command += "<phy-interface>" + interfaceFilter + "</phy-interface>"
+	}
+	command += "</interface></show></rpc>"
+
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "InterfaceHWSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape InterfaceHWSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml InterfaceHWSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+
+	for _, intf := range target.RPC.Show.Interface.Interfaces.Interface {
+		ch <- e.NewMetric(MetricDesc["Interface"]["network_if_rx_bytes"], prometheus.CounterValue, intf.Stats.RxBytes, intf.Name)
+		ch <- e.NewMetric(MetricDesc["Interface"]["network_if_tx_bytes"], prometheus.CounterValue, intf.Stats.TxBytes, intf.Name)
+		ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_if_rx_packets"], prometheus.CounterValue, intf.Stats.RxPackets, intf.Name)
+		ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_if_tx_packets"], prometheus.CounterValue, intf.Stats.TxPackets, intf.Name)
+		ch <- e.NewMetric(MetricDesc["Interface"]["network_if_state"], prometheus.GaugeValue, encodeMetricMulti(intf.State, []string{"Down", "Up"}), intf.Name)
+		ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_if_enabled"], prometheus.GaugeValue, encodeMetricMulti(intf.Enabled, []string{"No", "Yes"}), intf.Name)
+		if intf.LAG.ConfiguredMembers.Member != nil {
+			ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_lag_configured_members"], prometheus.GaugeValue, float64(len(intf.LAG.ConfiguredMembers.Member)), intf.Name)
+			ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_lag_available_members"], prometheus.GaugeValue, float64(len(intf.LAG.AvailableMembers.Member)), intf.Name)
+			ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_lag_operational_members"], prometheus.GaugeValue, float64(len(intf.LAG.OperationalMembers.Member)), intf.Name)
+		} else if len(intf.ETH.LinkDetected) > 0 {
+			ch <- e.NewMetric(MetricDesc["InterfaceHW"]["network_if_link_detected"], prometheus.GaugeValue, encodeMetricMulti(intf.ETH.LinkDetected, []string{"No", "Yes"}), intf.Name)
+		}
+	}
+
+	return 1, nil
+}

--- a/semp/getRaidSemp1.go
+++ b/semp/getRaidSemp1.go
@@ -1,0 +1,66 @@
+package semp
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Get system disk information (for Appliance)
+func (e *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (ok float64, err error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Disk struct {
+					DiskInfos struct {
+						InternalDisks struct {
+							DiskInfo []struct {
+								Number                     string  `xml:"number"`
+								AdministrativeStateEnabled bool    `xml:"administrative-state-enabled"`
+								State                      string  `xml:"state"`
+								DeviceModel                string  `xml:"device-model"`
+								Capacity                   float64 `xml:"capacity"`
+							} `xml:"disk-info"`
+							RaidState      string `xml:"raid-state"`
+							ReloadRequired bool   `xml:"reload-required"`
+						} `xml:"internal-disks"`
+					} `xml:"disk-infos"`
+				} `xml:"disk"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><disk></disk></show></rpc>"
+	body, err := e.postHTTP(e.brokerURI+"/SEMP", "application/xml", command, "RaidSemp1", 1)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't scrape GetRaidSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		_ = level.Error(e.logger).Log("msg", "Can't decode Xml GetRaidSemp1", "err", err, "broker", e.brokerURI)
+		return 0, err
+	}
+	if target.ExecuteResult.Result != "ok" {
+		_ = level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.brokerURI)
+		return 0, errors.New("unexpected result: see log")
+	}
+
+	for _, disk := range target.RPC.Show.Disk.DiskInfos.InternalDisks.DiskInfo {
+		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_capacity"], prometheus.GaugeValue, disk.Capacity, disk.Number, disk.DeviceModel)
+		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_state"], prometheus.GaugeValue, encodeMetricMulti(disk.State, []string{"Down", "Up", "-"}), disk.Number, disk.DeviceModel)
+		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_AdministrativeStateEnabled"], prometheus.GaugeValue, encodeMetricBool(disk.AdministrativeStateEnabled), disk.Number, disk.DeviceModel)
+	}
+
+	ch <- e.NewMetric(MetricDesc["Raid"]["system_raid_state"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Disk.DiskInfos.InternalDisks.RaidState, []string{"Disabled", "in fully redundant state", "-"}))
+	ch <- e.NewMetric(MetricDesc["Raid"]["system_reload_required"], prometheus.GaugeValue, encodeMetricBool(target.RPC.Show.Disk.DiskInfos.InternalDisks.ReloadRequired))
+
+	return 1, nil
+}

--- a/semp/getRaidSemp1.go
+++ b/semp/getRaidSemp1.go
@@ -54,7 +54,6 @@ func (e *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (ok float64, err error) 
 	}
 
 	for _, disk := range target.RPC.Show.Disk.DiskInfos.InternalDisks.DiskInfo {
-		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_capacity"], prometheus.GaugeValue, disk.Capacity, disk.Number, disk.DeviceModel)
 		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_state"], prometheus.GaugeValue, encodeMetricMulti(disk.State, []string{"Down", "Up", "-"}), disk.Number, disk.DeviceModel)
 		ch <- e.NewMetric(MetricDesc["Raid"]["system_disk_AdministrativeStateEnabled"], prometheus.GaugeValue, encodeMetricBool(disk.AdministrativeStateEnabled), disk.Number, disk.DeviceModel)
 	}

--- a/semp/getSpoolSemp1.go
+++ b/semp/getSpoolSemp1.go
@@ -50,9 +50,8 @@ func (e *Semp) GetSpoolSemp1(ch chan<- PrometheusMetric) (ok float64, err error)
 						MessagesCurrentlySpooledADB    float64 `xml:"rfad-messages-currently-spooled"`
 						MessagesCurrentlySpooledDisk   float64 `xml:"disk-messages-currently-spooled"`
 
-
-						QueueTopicSubscriptionsQuota   float64 `xml:"max-queue-topic-subscriptions"`
-						QueueTopicSubscriptionsUsed    float64 `xml:"queue-topic-subscriptions-used"`
+						QueueTopicSubscriptionsQuota float64 `xml:"max-queue-topic-subscriptions"`
+						QueueTopicSubscriptionsUsed  float64 `xml:"queue-topic-subscriptions-used"`
 					} `xml:"message-spool-info"`
 				} `xml:"message-spool"`
 			} `xml:"show"`
@@ -132,10 +131,10 @@ func (e *Semp) GetSpoolSemp1(ch chan<- PrometheusMetric) (ok float64, err error)
 	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_messages_currently_spooled_adb"], prometheus.GaugeValue, target.RPC.Show.Spool.Info.MessagesCurrentlySpooledADB)
 	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_messages_currently_spooled_disk"], prometheus.GaugeValue, target.RPC.Show.Spool.Info.MessagesCurrentlySpooledDisk)
 
-	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_messages_total_disk_usage"], prometheus.GaugeValue, target.RPC.Show.Spool.Info.CurrentDiskUsage)
-
-	// don't know what acceptable values are
-	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_sync_status"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Spool.Info.SpoolSyncStatus, []string{"Enabled", "Synced", "-", "N/A"}))
+	// this is probably more useful for appliances where ADB storage is independent of disk utilisation
+	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_messages_total_disk_usage_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.CurrentDiskUsage*1048576.0))
+	// I have been unable to ascertain what the error values for this metric are
+	ch <- e.NewMetric(MetricDesc["Spool"]["system_spool_sync_status"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Spool.Info.SpoolSyncStatus, []string{"Synced"}))
 
 	return 1, nil
 }

--- a/semp/metricDesc.go
+++ b/semp/metricDesc.go
@@ -122,7 +122,6 @@ var MetricDesc = map[string]Descriptions{
 		"system_total_tx_discards":       NewSemDesc("system_total_tx_discards", NoSempV2Ready, "Total egress discards.", nil),
 	},
 	"Raid": {
-		"system_disk_capacity":                   NewSemDesc("system_disk_capacity", NoSempV2Ready, "Available Capacity of the physical disk.", variableLabelsRaid),
 		"system_disk_state":                      NewSemDesc("system_disk_state", NoSempV2Ready, "Disk state. 0 = down, 1 = up.", variableLabelsRaid),
 		"system_disk_AdministrativeStateEnabled": NewSemDesc("system_disk_AdministrativeStateEnabled", NoSempV2Ready, "Disk enablement 0 = disabled, 1 = enabled.", variableLabelsRaid),
 		"system_raid_state":                      NewSemDesc("system_raid_state", NoSempV2Ready, "Current RAID state of the internal disks, 1 if fully redundant.", nil),
@@ -159,8 +158,8 @@ var MetricDesc = map[string]Descriptions{
 		"system_spool_messages_currently_spooled_adb":     NewSemDesc("system_spool_messages_currently_spooled_adb", NoSempV2Ready, "Messages stored in adb.", nil),
 		"system_spool_messages_currently_spooled_disk":    NewSemDesc("system_spool_messages_currently_spooled_disk", NoSempV2Ready, "Messages stored on disk.", nil),
 		"system_spool_transacted_session_utilisation_pct": NewSemDesc("system_spool_transacted_session_utilisation_pct", NoSempV2Ready, "Percentage of transacted sessions used.", nil),
-		"system_spool_messages_total_disk_usage":          NewSemDesc("system_spool_messages_total_disk_usage", NoSempV2Ready, "Total disk usage, MB.", nil),
-		"system_spool_sync_status":                        NewSemDesc("system_spool_sync_status", NoSempV2Ready, "Spool sync status: 1-Synced.", nil),
+		"system_spool_messages_total_disk_usage_bytes":    NewSemDesc("system_spool_messages_total_disk_usage_bytes", NoSempV2Ready, "Total disk usage.", nil),
+		"system_spool_sync_status":                        NewSemDesc("system_spool_sync_status", NoSempV2Ready, "Spool sync status: 0-Synced.", nil),
 	},
 	"Redundancy": {
 		"system_redundancy_up":           NewSemDesc("system_redundancy_up", NoSempV2Ready, "Is redundancy up? (0=Down, 1=Up).", variableLabelsRedundancy),
@@ -175,9 +174,9 @@ var MetricDesc = map[string]Descriptions{
 		"system_redundancy_adb_hello": NewSemDesc("system_redundancy_adb_hello", NoSempV2Ready, "Is adb link connected? (0-no, 1-yes).", variableLabelsRedundancy),
 	},
 	"Environment": {
-		"system_chassis_fan_speed":    NewSemDesc("system_chassis_fan_speed", NoSempV2Ready, "Chassis Fan Speed (RPM)", variableLabelsEnvironment),
-		"system_cpu_thermal_margin":   NewSemDesc("system_cpu_thermal_margin", NoSempV2Ready, "CPU thermal headroom (Degrees C, larger negative values are better.)", variableLabelsEnvironment),
-		"system_nab_core_temperature": NewSemDesc("system_nab_core_temperature", NoSempV2Ready, "NAB core temperature (Degrees C).", variableLabelsEnvironment),
+		"system_chassis_fan_speed_rpm": NewSemDesc("system_chassis_fan_speed_rpm", NoSempV2Ready, "Chassis Fan Speed (RPM)", variableLabelsEnvironment),
+		"system_cpu_thermal_margin":    NewSemDesc("system_cpu_thermal_margin", NoSempV2Ready, "CPU thermal headroom (Degrees C, larger negative values are better.)", variableLabelsEnvironment),
+		"system_nab_core_temperature":  NewSemDesc("system_nab_core_temperature", NoSempV2Ready, "NAB core temperature (Degrees C).", variableLabelsEnvironment),
 	},
 	"Hardware": {
 		"operational_power_supplies":      NewSemDesc("operational_power_supplies", NoSempV2Ready, "Number of operational power supplies", nil),

--- a/semp/semp.struct.go
+++ b/semp/semp.struct.go
@@ -13,10 +13,11 @@ type Semp struct {
 	brokerURI               string
 	exporterVersion         float64
 	logBrokerToSlowWarnings bool
+	isHWBroker              bool
 }
 
 // NewSemp returns an initialized Semp.
-func NewSemp(logger log.Logger, brokerURI string, httpClient http.Client, httpRequestVisitor func(*http.Request), exporterVersion float64, logBrokerToSlowWarnings bool) *Semp {
+func NewSemp(logger log.Logger, brokerURI string, httpClient http.Client, httpRequestVisitor func(*http.Request), exporterVersion float64, logBrokerToSlowWarnings bool, isHWBroker bool) *Semp {
 	return &Semp{
 		logger:                  logger,
 		brokerURI:               brokerURI,
@@ -24,5 +25,6 @@ func NewSemp(logger log.Logger, brokerURI string, httpClient http.Client, httpRe
 		httpRequestVisitor:      httpRequestVisitor,
 		exporterVersion:         exporterVersion,
 		logBrokerToSlowWarnings: logBrokerToSlowWarnings,
+		isHWBroker:              isHWBroker,
 	}
 }

--- a/solace_prometheus_exporter.go
+++ b/solace_prometheus_exporter.go
@@ -200,18 +200,22 @@ func main() {
 				Not all scrape targets support filter.
 				<br>Scrape targets:<br>
 				<table><tr><th>scape target</th><th>vpn filter supports</th><th>item filter supported</th><th>performance</th><tr>
-					<tr><td>Version</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>Version</td><td>no</td><td>no</td><td>dont harm broker</td></tr>`))
+		if !conf.IsHWBroker {
+			w.Write([]byte(`					
 					<tr><td>Health</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>StorageElement</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
-					<tr><td>Disk</td><td>no</td><td>yes</td><td>dont harm broker</td></tr>
+					<tr><td>Disk</td><td>no</td><td>yes</td><td>dont harm broker</td></tr>`))
+		}
+		w.Write([]byte(`					
 					<tr><td>Memory</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>Interface</td><td>no</td><td>yes</td><td>dont harm broker</td></tr>
 					<tr><td>GlobalStats</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>Spool</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
-					<tr><td>Redundancy (only for HA broker)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
-					<tr><td>ConfigSync (only for HA broker)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
-					<tr><td>ConfigSyncRouter (only for HA broker)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
-					<tr><td>ReplicationStats (only for DR replication broker)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>Redundancy (only for HA brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>ConfigSync (only for HA brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>ConfigSyncRouter (only for HA brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>ReplicationStats (only for DR replication brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>Vpn</td><td>yes</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>VpnReplication</td><td>yes</td><td>no</td><td>dont harm broker</td></tr>
 					<tr><td>ConfigSyncVpn (only for HA broker)</td><td>yes</td><td>no</td><td>dont harm broker</td></tr>
@@ -232,6 +236,17 @@ func main() {
 					<tr><td>TopicEndpointRates</td><td>yes</td><td>yes</td><td>DEPRECATED: may harm broker if many topic-endpoints</td></tr>
 					<tr><td>TopicEndpointStats</td><td>yes</td><td>yes</td><td>may harm broker if many topic-endpoints</td></tr>
 					<tr><td>TopicEndpointDetails</td><td>yes</td><td>yes</td><td>may harm broker if many topic-endpoints</td></tr>
+					<tr><td>BridgeRemote</td><td>yes</td><td>yes</td><td>dont harm broker</td></tr>`))
+
+		if conf.IsHWBroker == true {
+			w.Write([]byte(`					
+					<tr><td>Alarm (only for Hardware brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>Environment (only for Hardware brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>Hardware (only for Hardware brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>
+					<tr><td>InterfaceHW (only for Hardware brokers)</td><td>no</td><td>yes</td><td>dont harm broker</td></tr>
+					<tr><td>Raid (only for Hardware brokers)</td><td>no</td><td>no</td><td>dont harm broker</td></tr>`))
+		}
+		w.Write([]byte(`				
 				</table>
 				<br>
 				</p>
@@ -239,6 +254,7 @@ func main() {
             <ul>
             </body>
             </html>`))
+
 	})
 
 	// start server

--- a/solace_prometheus_exporter.ini
+++ b/solace_prometheus_exporter.ini
@@ -53,6 +53,9 @@ prefetchInterval=0s
 # Dont increase this value if your broker may have more thant 100 clients, queues, ...
 parallelSempConnections=1
 
+# Flag that enables HW Broker specific targets and disables SW specific ones.
+isHWBroker=false
+
 [endpoint.solace-v1-test]
 QueueStats = AaaBbbCcc|*
 


### PR DESCRIPTION
This update adds:
- a flag to distinguish HW and SW brokers
- enables or disables HW only or SW only targets depending on the flag
- modifies some targets to supply different metrics for SW and HW brokers or use different SEMP queries
- several hardware only targets
- minor updates to some targets to add additional metrics e.g. spool + transactions
- a new version of the bridge target which adds labels for remote VPNs and Routers
- along with readme updates