### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This pull request adds configuration to enable Dependabot for automated dependency management in the projects GitHub actions. Dependabot helps to ensure that the dependencies remain up-to-date with the latest versions, improving security and compatibility.

Additionally to the code changes, Dependabot must be enabled under `Settings` > `Code security` > `Dependabot` > `Dependabot version updates`.