### PR TITLE
#91 solace_up metric contains more information and is less fast failing

### DIFF
--- a/semp/getClientMessageSpoolStatsSemp1.go
+++ b/semp/getClientMessageSpoolStatsSemp1.go
@@ -65,6 +65,7 @@ func (semp *Semp) GetClientMessageSpoolStatsSemp1(ch chan<- PrometheusMetric, it
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -75,7 +76,7 @@ func (semp *Semp) GetClientMessageSpoolStatsSemp1(ch chan<- PrometheusMetric, it
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape ClientMessageSpoolStatsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -87,7 +88,7 @@ func (semp *Semp) GetClientMessageSpoolStatsSemp1(ch chan<- PrometheusMetric, it
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getClientSemp1.go
+++ b/semp/getClientSemp1.go
@@ -31,6 +31,7 @@ func (semp *Semp) GetClientSemp1(ch chan<- PrometheusMetric, vpnFilter string, i
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -41,7 +42,7 @@ func (semp *Semp) GetClientSemp1(ch chan<- PrometheusMetric, vpnFilter string, i
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape ClientSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -53,7 +54,7 @@ func (semp *Semp) GetClientSemp1(ch chan<- PrometheusMetric, vpnFilter string, i
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getClientSlowSubscriberSemp1.go
+++ b/semp/getClientSlowSubscriberSemp1.go
@@ -32,6 +32,7 @@ func (semp *Semp) GetClientSlowSubscriberSemp1(ch chan<- PrometheusMetric, vpnFi
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -42,7 +43,7 @@ func (semp *Semp) GetClientSlowSubscriberSemp1(ch chan<- PrometheusMetric, vpnFi
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape ClientSlowSubscriberSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -54,7 +55,7 @@ func (semp *Semp) GetClientSlowSubscriberSemp1(ch chan<- PrometheusMetric, vpnFi
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getClusterLinksSemp1.go
+++ b/semp/getClusterLinksSemp1.go
@@ -33,6 +33,7 @@ func (semp *Semp) GetClusterLinksSemp1(ch chan<- PrometheusMetric, clusterFilter
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -40,7 +41,7 @@ func (semp *Semp) GetClusterLinksSemp1(ch chan<- PrometheusMetric, clusterFilter
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "ClusterLinksSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape ClusterLinksSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -51,8 +52,8 @@ func (semp *Semp) GetClusterLinksSemp1(ch chan<- PrometheusMetric, clusterFilter
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, cluster := range target.RPC.Show.Cluster.Clusters.Cluster {

--- a/semp/getConfigSyncRouterSemp1.go
+++ b/semp/getConfigSyncRouterSemp1.go
@@ -32,6 +32,7 @@ func (semp *Semp) GetConfigSyncRouterSemp1(ch chan<- PrometheusMetric) (ok float
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -39,7 +40,7 @@ func (semp *Semp) GetConfigSyncRouterSemp1(ch chan<- PrometheusMetric) (ok float
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "ConfigSyncRouterSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -50,8 +51,8 @@ func (semp *Semp) GetConfigSyncRouterSemp1(ch chan<- PrometheusMetric) (ok float
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {

--- a/semp/getConfigSyncVpnSemp1.go
+++ b/semp/getConfigSyncVpnSemp1.go
@@ -32,6 +32,7 @@ func (semp *Semp) GetConfigSyncVpnSemp1(ch chan<- PrometheusMetric, vpnFilter st
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -39,7 +40,7 @@ func (semp *Semp) GetConfigSyncVpnSemp1(ch chan<- PrometheusMetric, vpnFilter st
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "ConfigSyncVpnSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -50,8 +51,8 @@ func (semp *Semp) GetConfigSyncVpnSemp1(ch chan<- PrometheusMetric, vpnFilter st
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {

--- a/semp/getDiskSemp1.go
+++ b/semp/getDiskSemp1.go
@@ -30,6 +30,7 @@ func (semp *Semp) GetDiskSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -37,7 +38,7 @@ func (semp *Semp) GetDiskSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "DiskSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape DiskSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -48,8 +49,8 @@ func (semp *Semp) GetDiskSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	blockSize := 1024.0

--- a/semp/getEnvironmentSemp1.go
+++ b/semp/getEnvironmentSemp1.go
@@ -47,6 +47,7 @@ func (semp *Semp) GetEnvironmentSemp1(ch chan<- PrometheusMetric) (ok float64, e
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -54,7 +55,7 @@ func (semp *Semp) GetEnvironmentSemp1(ch chan<- PrometheusMetric) (ok float64, e
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "EnvironmentSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape EnvironmentSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -65,8 +66,8 @@ func (semp *Semp) GetEnvironmentSemp1(ch chan<- PrometheusMetric) (ok float64, e
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, sensor := range target.RPC.Show.Environment.Mainboard.Sensors.Sensor {

--- a/semp/getGlobalStatsSemp1.go
+++ b/semp/getGlobalStatsSemp1.go
@@ -23,6 +23,7 @@ func (semp *Semp) GetGlobalSystemInfoSemp1(ch chan<- PrometheusMetric) (ok float
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -30,7 +31,7 @@ func (semp *Semp) GetGlobalSystemInfoSemp1(ch chan<- PrometheusMetric) (ok float
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "GetGlobalSystemInfoSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape GetGlobalSystemInfoSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -41,8 +42,8 @@ func (semp *Semp) GetGlobalSystemInfoSemp1(ch chan<- PrometheusMetric) (ok float
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	ch <- semp.NewMetric(MetricDesc["GlobalStats"]["system_uptime_seconds"], prometheus.CounterValue, target.RPC.Show.System.UptimeSeconds)
@@ -85,6 +86,7 @@ func (semp *Semp) GetGlobalStatsSemp1(ch chan<- PrometheusMetric) (ok float64, e
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -92,7 +94,7 @@ func (semp *Semp) GetGlobalStatsSemp1(ch chan<- PrometheusMetric) (ok float64, e
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "GlobalStatsSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape GlobalStatsSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -103,8 +105,8 @@ func (semp *Semp) GetGlobalStatsSemp1(ch chan<- PrometheusMetric) (ok float64, e
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	ch <- semp.NewMetric(MetricDesc["GlobalStats"]["system_total_clients_connected"], prometheus.GaugeValue, target.RPC.Show.Stats.Client.Global.Stats.ClientsConnected)

--- a/semp/getHardwareSemp1.go
+++ b/semp/getHardwareSemp1.go
@@ -42,6 +42,7 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (ok float64, err 
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -49,7 +50,7 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (ok float64, err 
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "HardwareSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape HardwareSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -60,8 +61,8 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (ok float64, err 
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	ch <- semp.NewMetric(MetricDesc["Hardware"]["operational_power_supplies"], prometheus.GaugeValue, target.RPC.Show.Hardware.PowerRedundancy.OperationalPowerSupplies)

--- a/semp/getHealthSemp1.go
+++ b/semp/getHealthSemp1.go
@@ -32,6 +32,7 @@ func (semp *Semp) GetHealthSemp1(ch chan<- PrometheusMetric) (ok float64, err er
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -39,7 +40,7 @@ func (semp *Semp) GetHealthSemp1(ch chan<- PrometheusMetric) (ok float64, err er
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "HealthSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape HealthSemp1. Attention this is only supported by software broker not by appliances", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -50,8 +51,8 @@ func (semp *Semp) GetHealthSemp1(ch chan<- PrometheusMetric) (ok float64, err er
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	ch <- semp.NewMetric(MetricDesc["Health"]["system_disk_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMinimumValue/1e6)

--- a/semp/getInterfaceHWSemp1.go
+++ b/semp/getInterfaceHWSemp1.go
@@ -48,6 +48,7 @@ func (semp *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilte
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -61,7 +62,7 @@ func (semp *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilte
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "InterfaceHWSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape InterfaceHWSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -72,8 +73,8 @@ func (semp *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilte
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, intf := range target.RPC.Show.Interface.Interfaces.Interface {

--- a/semp/getInterfaceSemp1.go
+++ b/semp/getInterfaceSemp1.go
@@ -29,6 +29,7 @@ func (semp *Semp) GetInterfaceSemp1(ch chan<- PrometheusMetric, interfaceFilter 
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -36,7 +37,7 @@ func (semp *Semp) GetInterfaceSemp1(ch chan<- PrometheusMetric, interfaceFilter 
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "InterfaceSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape InterfaceSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -47,8 +48,8 @@ func (semp *Semp) GetInterfaceSemp1(ch chan<- PrometheusMetric, interfaceFilter 
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, intf := range target.RPC.Show.Interface.Interfaces.Interface {

--- a/semp/getQueueDetailsSemp1.go
+++ b/semp/getQueueDetailsSemp1.go
@@ -36,6 +36,7 @@ func (semp *Semp) GetQueueDetailsSemp1(ch chan<- PrometheusMetric, vpnFilter str
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -47,7 +48,7 @@ func (semp *Semp) GetQueueDetailsSemp1(ch chan<- PrometheusMetric, vpnFilter str
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape QueueDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -59,7 +60,7 @@ func (semp *Semp) GetQueueDetailsSemp1(ch chan<- PrometheusMetric, vpnFilter str
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape QueueDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getQueueRatesSemp1.go
+++ b/semp/getQueueRatesSemp1.go
@@ -43,6 +43,7 @@ func (semp *Semp) GetQueueRatesSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -54,7 +55,7 @@ func (semp *Semp) GetQueueRatesSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape QueueRatesSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -66,7 +67,7 @@ func (semp *Semp) GetQueueRatesSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getQueueStatsSemp1.go
+++ b/semp/getQueueStatsSemp1.go
@@ -50,6 +50,7 @@ func (semp *Semp) GetQueueStatsSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -61,7 +62,7 @@ func (semp *Semp) GetQueueStatsSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape QueueStatsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -73,7 +74,7 @@ func (semp *Semp) GetQueueStatsSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		_ = level.Debug(semp.logger).Log("msg", "Result of QueueStatsSemp1", "results", len(target.RPC.Show.Queue.Queues.Queue), "page", page-1)

--- a/semp/getRaidSemp1.go
+++ b/semp/getRaidSemp1.go
@@ -31,6 +31,7 @@ func (semp *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -38,7 +39,7 @@ func (semp *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "RaidSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape GetRaidSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -49,8 +50,8 @@ func (semp *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (ok float64, err erro
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, disk := range target.RPC.Show.Disk.DiskInfos.InternalDisks.DiskInfo {

--- a/semp/getRestConsumerStatsSemp1.go
+++ b/semp/getRestConsumerStatsSemp1.go
@@ -40,6 +40,7 @@ func (semp *Semp) GetRestConsumerStatsSemp1(ch chan<- PrometheusMetric, vpnFilte
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -52,7 +53,7 @@ func (semp *Semp) GetRestConsumerStatsSemp1(ch chan<- PrometheusMetric, vpnFilte
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape RestConsumerStatsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -64,7 +65,7 @@ func (semp *Semp) GetRestConsumerStatsSemp1(ch chan<- PrometheusMetric, vpnFilte
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		_ = level.Debug(semp.logger).Log("msg", "Result of RestConsumerStatsSemp1", "results", len(target.RPC.Show.MessageVpn.RestConsumerInfo.StatsInfo), "page", page-1)

--- a/semp/getStorageElementSemp1.go
+++ b/semp/getStorageElementSemp1.go
@@ -27,6 +27,7 @@ func (semp *Semp) GetStorageElementSemp1(ch chan<- PrometheusMetric, storageElem
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -34,7 +35,7 @@ func (semp *Semp) GetStorageElementSemp1(ch chan<- PrometheusMetric, storageElem
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "StorageElementSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape StorageElementSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -45,8 +46,8 @@ func (semp *Semp) GetStorageElementSemp1(ch chan<- PrometheusMetric, storageElem
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	blockSize := 1024.0

--- a/semp/getTopicEndpointDetailsSemp1.go
+++ b/semp/getTopicEndpointDetailsSemp1.go
@@ -35,6 +35,7 @@ func (semp *Semp) GetTopicEndpointDetailsSemp1(ch chan<- PrometheusMetric, vpnFi
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -46,7 +47,7 @@ func (semp *Semp) GetTopicEndpointDetailsSemp1(ch chan<- PrometheusMetric, vpnFi
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape TopicEndpointDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -58,7 +59,7 @@ func (semp *Semp) GetTopicEndpointDetailsSemp1(ch chan<- PrometheusMetric, vpnFi
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape TopicEndpointDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getTopicEndpointRatesSemp1.go
+++ b/semp/getTopicEndpointRatesSemp1.go
@@ -43,6 +43,7 @@ func (semp *Semp) GetTopicEndpointRatesSemp1(ch chan<- PrometheusMetric, vpnFilt
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -54,7 +55,7 @@ func (semp *Semp) GetTopicEndpointRatesSemp1(ch chan<- PrometheusMetric, vpnFilt
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape TopicEndpointRatesSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -66,7 +67,7 @@ func (semp *Semp) GetTopicEndpointRatesSemp1(ch chan<- PrometheusMetric, vpnFilt
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		nextRequest = target.MoreCookie.RPC

--- a/semp/getTopicEndpointStatsSemp1.go
+++ b/semp/getTopicEndpointStatsSemp1.go
@@ -50,6 +50,7 @@ func (semp *Semp) GetTopicEndpointStatsSemp1(ch chan<- PrometheusMetric, vpnFilt
 		} `xml:"more-cookie"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -61,7 +62,7 @@ func (semp *Semp) GetTopicEndpointStatsSemp1(ch chan<- PrometheusMetric, vpnFilt
 
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape TopicEndpointStatsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, err
+			return -1, err
 		}
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
@@ -73,7 +74,7 @@ func (semp *Semp) GetTopicEndpointStatsSemp1(ch chan<- PrometheusMetric, vpnFilt
 		}
 		if target.ExecuteResult.Result != "ok" {
 			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: see log")
+			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 		}
 
 		//fmt.Printf("Next request: %v\n", target.MoreCookie.RPC)

--- a/semp/getVersionSemp1.go
+++ b/semp/getVersionSemp1.go
@@ -31,6 +31,7 @@ func (semp *Semp) GetVersionSemp1(ch chan<- PrometheusMetric) (ok float64, err e
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -38,7 +39,7 @@ func (semp *Semp) GetVersionSemp1(ch chan<- PrometheusMetric) (ok float64, err e
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "VersionSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape getVersionSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -49,8 +50,8 @@ func (semp *Semp) GetVersionSemp1(ch chan<- PrometheusMetric) (ok float64, err e
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "Unexpected result for getVersionSemp1", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "Unexpected result for getVersionSemp1", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	// remember this for the label

--- a/semp/getVpnSemp1.go
+++ b/semp/getVpnSemp1.go
@@ -32,6 +32,7 @@ func (semp *Semp) GetVpnSemp1(ch chan<- PrometheusMetric, vpnFilter string) (ok 
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -39,7 +40,7 @@ func (semp *Semp) GetVpnSemp1(ch chan<- PrometheusMetric, vpnFilter string) (ok 
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "VpnSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -50,8 +51,8 @@ func (semp *Semp) GetVpnSemp1(ch chan<- PrometheusMetric, vpnFilter string) (ok 
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "Unexpected result for VpnSemp1", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "Unexpected result for VpnSemp1", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Vpn {

--- a/semp/getVpnSpoolSemp1.go
+++ b/semp/getVpnSpoolSemp1.go
@@ -35,6 +35,7 @@ func (semp *Semp) GetVpnSpoolSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -42,7 +43,7 @@ func (semp *Semp) GetVpnSpoolSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "VpnSpoolSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -53,8 +54,8 @@ func (semp *Semp) GetVpnSpoolSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, vpn := range target.RPC.Show.MessageSpool.MessageVpn.Vpn {

--- a/semp/getVpnStatsSemp1.go
+++ b/semp/getVpnStatsSemp1.go
@@ -56,6 +56,7 @@ func (semp *Semp) GetVpnStatsSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 		} `xml:"rpc"`
 		ExecuteResult struct {
 			Result string `xml:"code,attr"`
+			Reason string `xml:"reason,attr"`
 		} `xml:"execute-result"`
 	}
 
@@ -63,7 +64,7 @@ func (semp *Semp) GetVpnStatsSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 	body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "VpnStatsSemp1", 1)
 	if err != nil {
 		_ = level.Error(semp.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", semp.brokerURI)
-		return 0, err
+		return -1, err
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -74,8 +75,8 @@ func (semp *Semp) GetVpnStatsSemp1(ch chan<- PrometheusMetric, vpnFilter string)
 		return 0, err
 	}
 	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: see log")
+		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
+		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Vpn {


### PR DESCRIPTION
## Actual situation:

When i scrape multiple sources (multiple semp queries agains the same broker) 
an error will abort scraping and metrics will be returened may be partly.

## Wanted change:

Network-related errors, such as 'broker unreachable,' should result in the immediate aborting of all further sources.
In contrast, errors that pertain to a single source, like permission issues, should only cause that specific source to be skipped while allowing the processing of all other sources to continue.

In following examples and their results with new change:

### Valid query:

```
curl --location 'http://localhost:9628/solace?m.Version=*%7C*&m.GlobalSystemInfo=*%7C*' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'scrapeURI=https://mr-connection-xxxxxx.messaging.solace.cloud:943' \
--data-urlencode 'username=xxxxx-view' \
--data-urlencode 'password=*******'
```

#### Result:
```
### .... all metrics ....

# HELP solace_up Was the last scrape of Solace broker successful.
# TYPE solace_up gauge
solace_up{error=""} 1
```


### Query not reachable host:

```
curl --location 'http://localhost:9628/solace?m.Version=*%7C*&m.GlobalSystemInfo=*%7C*' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'scrapeURI=https://mr-connection-DOES-NOT-EXIST.messaging.solace.cloud:943' \
--data-urlencode 'username=xxxxx-view' \
--data-urlencode 'password=*******'
```

#### Result:
```
# HELP solace_up Was the last scrape of Solace broker successful.
# TYPE solace_up gauge
solace_up{error=""} 1
solace_up{error="Post \"https://mr-connection-DOES-NOT-EXIST.solace.cloud:943/SEMP\": dial tcp: lookup mr-connection-DOES-NOT-EXIST.solace.cloud: no such host"} 0
```


### Query not reachable host:

```
curl --location 'http://localhost:9628/solace?m.Version=*%7C*&m.Client=rcs%7C*' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'scrapeURI=https://mr-connection-xxxxxx.messaging.solace.cloud:943' \
--data-urlencode 'username=only-permitted-to-single-vpn' \
--data-urlencode 'password=*******'
```

#### Result:
```
### .... metrics of all possible sources ....

# HELP solace_up Was the last scrape of Solace broker successful.
# TYPE solace_up gauge
solace_up{error=""} 1
solace_up{error="Version: unexpected result: unauthorized. see log for further details"} 0
```

