### PR TITLE
Remove incorrect Apache license header

### DIFF
--- a/cmd/solace-prometheus-exporter/main.go
+++ b/cmd/solace-prometheus-exporter/main.go
@@ -1,15 +1,3 @@
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main
 
 import (


### PR DESCRIPTION
This PR cleans up an incorrect license header in the main.go source file.
The repository is licensed under MIT, but the file contained an Apache license comment, which could cause confusion. The incorrect header has been removed to keep the licensing information consistent and aligned with the project’s actual license.