### PR TITLE
Remove metric exporter_version_current

### DIFF
--- a/cmd/solace-prometheus-exporter/main.go
+++ b/cmd/solace-prometheus-exporter/main.go
@@ -19,8 +19,6 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const version = float64(1004005)
-
 func logDataSource(dataSources []exporter.DataSource) string {
 	dS := make([]string, len(dataSources))
 	for index, dataSource := range dataSources {
@@ -78,7 +76,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	level.Info(logger).Log("msg", "Starting solace_prometheus_exporter", "version", version)
+	level.Info(logger).Log("msg", "Starting solace_prometheus_exporter")
 	level.Info(logger).Log("msg", "Build context", "context", promVersion.BuildContext())
 
 	if *enableTLS {
@@ -117,7 +115,7 @@ func main() {
 		_ = level.Info(logger).Log("msg", "Register handler from config", "handler", "/"+urlPath, "dataSource", logDataSource(dataSource))
 
 		if conf.PrefetchInterval.Seconds() > 0 {
-			var asyncFetcher = exporter.NewAsyncFetcher(urlPath, dataSource, *conf, logger, sempConnections, version)
+			var asyncFetcher = exporter.NewAsyncFetcher(urlPath, dataSource, *conf, logger, sempConnections)
 			http.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
 				doHandleAsync(w, r, asyncFetcher)
 			})
@@ -301,7 +299,7 @@ func doHandle(w http.ResponseWriter, r *http.Request, dataSource []exporter.Data
 
 		level.Info(logger).Log("msg", "handle http request", "dataSource", logDataSource(dataSource), "scrapeURI", conf.ScrapeURI)
 
-		exp := exporter.NewExporter(logger, &conf, &dataSource, version)
+		exp := exporter.NewExporter(logger, &conf, &dataSource)
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(exp)
 		handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})

--- a/internal/exporter/asyncFetcher.go
+++ b/internal/exporter/asyncFetcher.go
@@ -17,13 +17,13 @@ const (
 	capMetricChan = 1000
 )
 
-func NewAsyncFetcher(urlPath string, dataSource []DataSource, conf Config, logger log.Logger, connections *semaphore.Weighted, version float64) *AsyncFetcher {
+func NewAsyncFetcher(urlPath string, dataSource []DataSource, conf Config, logger log.Logger, connections *semaphore.Weighted) *AsyncFetcher {
 	var fetcher = &AsyncFetcher{
 		dataSource: dataSource,
 		conf:       conf,
 		logger:     logger,
 		metrics:    make(map[string]semp.PrometheusMetric),
-		exporter:   NewExporter(logger, &conf, &dataSource, version),
+		exporter:   NewExporter(logger, &conf, &dataSource),
 	}
 
 	collectWorker := func() {

--- a/internal/exporter/exporter.struct.go
+++ b/internal/exporter/exporter.struct.go
@@ -18,7 +18,7 @@ type Exporter struct {
 }
 
 // NewExporter returns an initialized Exporter.
-func NewExporter(logger log.Logger, conf *Config, dataSource *[]DataSource, version float64) *Exporter {
+func NewExporter(logger log.Logger, conf *Config, dataSource *[]DataSource) *Exporter {
 	httpVisitor, err := conf.httpVisitor()
 	if err != nil {
 		_ = level.Error(logger).Log("msg", "Failed to create HTTP visitor for exporter", "err", err)
@@ -29,6 +29,6 @@ func NewExporter(logger log.Logger, conf *Config, dataSource *[]DataSource, vers
 		config:     conf,
 		dataSource: dataSource,
 		lastError:  nil,
-		semp:       semp.NewSemp(logger, conf.ScrapeURI, conf.newHTTPClient(), httpVisitor, version, conf.logBrokerToSlowWarnings, conf.IsHWBroker),
+		semp:       semp.NewSemp(logger, conf.ScrapeURI, conf.newHTTPClient(), httpVisitor, conf.logBrokerToSlowWarnings, conf.IsHWBroker),
 	}
 }

--- a/internal/semp/getVersionSemp1.go
+++ b/internal/semp/getVersionSemp1.go
@@ -67,7 +67,6 @@ func (semp *Semp) GetVersionSemp1(ch chan<- PrometheusMetric) (float64, error) {
 
 	ch <- semp.NewMetric(MetricDesc["Version"]["system_version_currentload"], prometheus.GaugeValue, vmrVersionNr)
 	ch <- semp.NewMetric(MetricDesc["Version"]["system_version_uptime_totalsecs"], prometheus.GaugeValue, target.RPC.Show.Version.Uptime.TotalSecs)
-	ch <- semp.NewMetric(MetricDesc["Version"]["exporter_version_current"], prometheus.GaugeValue, semp.exporterVersion)
 
 	return 1, nil
 }

--- a/internal/semp/metricDesc.go
+++ b/internal/semp/metricDesc.go
@@ -64,7 +64,6 @@ var MetricDesc = map[string]Descriptions{
 	"Version": {
 		"system_version_currentload":      NewSemDesc("system_version_currentload", NoSempV2Ready, "Solace Version as WWWXXXYYYZZZ", nil),
 		"system_version_uptime_totalsecs": NewSemDesc("system_version_uptime_totalsecs", NoSempV2Ready, "Broker uptime in seconds", nil),
-		"exporter_version_current":        NewSemDesc("exporter_version_current", NoSempV2Ready, "Exporter Version as XXXYYYZZZ", nil),
 	},
 	"Health": {
 		"system_disk_latency_min_seconds":      NewSemDesc("system_disk_latency_min_seconds", NoSempV2Ready, "Minimum disk latency.", nil),

--- a/internal/semp/semp.struct.go
+++ b/internal/semp/semp.struct.go
@@ -12,19 +12,17 @@ type Semp struct {
 	httpClient              http.Client
 	httpRequestVisitor      func(*http.Request)
 	brokerURI               string
-	exporterVersion         float64
 	logBrokerToSlowWarnings bool
 	isHWBroker              bool
 }
 
 // NewSemp returns an initialized Semp.
-func NewSemp(logger log.Logger, brokerURI string, httpClient http.Client, httpRequestVisitor func(*http.Request), exporterVersion float64, logBrokerToSlowWarnings bool, isHWBroker bool) *Semp {
+func NewSemp(logger log.Logger, brokerURI string, httpClient http.Client, httpRequestVisitor func(*http.Request), logBrokerToSlowWarnings bool, isHWBroker bool) *Semp {
 	return &Semp{
 		logger:                  logger,
 		brokerURI:               brokerURI,
 		httpClient:              httpClient,
 		httpRequestVisitor:      httpRequestVisitor,
-		exporterVersion:         exporterVersion,
 		logBrokerToSlowWarnings: logBrokerToSlowWarnings,
 		isHWBroker:              isHWBroker,
 	}


### PR DESCRIPTION
This change removes the exporter_version_current metric because it was emitting a static value (1004005) and did not reflect the actual exporter version. Keeping it could lead to confusion.