### PR TITLE
Add basic authentication support for exporter endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,21 @@ prefetchInterval = 30s
 # Maximum connections to the configured broker. Keep in mind solace advices us to use max 10 SEMP connects per seconds.
 # Dont increase this value if your broker may have more thant 100 clients, queues, ...
 parallelSempConnections = 1
+
+# Authentication scheme for protecting the exporter endpoints
+# Supported values:
+#   none  - no authentication required (default)
+#   basic - HTTP Basic Authentication required
+# Can be overridden via env variable SOLACE_EXPORTER_AUTH_SCHEME
+exporterAuthScheme = basic
+
+# Username used when exporterAuthScheme = "basic"
+# Can be overridden via env variable SOLACE_EXPORTER_AUTH_USERNAME
+exporterAuthUsername = monitor
+
+# Password used when exporterAuthScheme = "basic"
+# Can be overridden via env variable SOLACE_EXPORTER_AUTH_PASSWORD
+exporterAuthPassword = changeit
 ```
 
 ### Environment Variables
@@ -395,6 +410,9 @@ SOLACE_OAUTH_CLIENT_ID=your-client-id
 SOLACE_OAUTH_CLIENT_SECRET=your-client-secret
 SOLACE_TIMEOUT=5s
 SOLACE_SSL_VERIFY=false
+SOLACE_EXPORTER_AUTH_SCHEME=basic
+SOLACE_EXPORTER_AUTH_USERNAME=monitor
+SOLACE_EXPORTER_AUTH_PASSWORD=changeit
 ```
 
 ### Authentication
@@ -412,6 +430,16 @@ If both basic auth (username/password) and OAuth (token URL, client ID and secre
 
 OAuth authentication is implemented using [golang.org/x/oauth2](https://pkg.go.dev/golang.org/x/oauth2) so every OAuth2-compliant provider should work properly.
 
+#### Securing the Exporter Endpoint
+The exporter now supports optional authentication for its own HTTP endpoints (including `/`, `/solace` and `/metrics`).
+
+|Config Key|Env Variable|Description|
+|-|-|-|
+|exporterAuthScheme|SOLACE_EXPORTER_AUTH_SCHEME|none or basic|
+|exporterAuthUsername|SOLACE_EXPORTER_AUTH_USERNAME|Username for basic auth|
+|exporterAuthPassword|SOLACE_EXPORTER_AUTH_PASSWORD|Password for basic auth|
+
+Default scheme is `none`, meaning no authentication is required unless configured. When basic is enabled, both username and password must be provided.
 ### URL
 
 You can call:

--- a/internal/exporter/config.struct.go
+++ b/internal/exporter/config.struct.go
@@ -13,6 +13,12 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+type ExporterAuthConfig struct {
+	Scheme   string
+	Username string
+	Password string
+}
+
 // Config Collection of configs
 type Config struct {
 	ListenAddr              string
@@ -40,6 +46,7 @@ type Config struct {
 	oAuthAccessToken        string
 	oAuthTokenExpiry        time.Time
 	authType                AuthType
+	ExporterAuth            ExporterAuthConfig
 }
 
 const (
@@ -74,6 +81,18 @@ func ParseConfig(configFile string) (map[string][]DataSource, *Config, error) {
 		}
 	}
 
+	conf.ExporterAuth.Scheme, err = parseConfigStringOptional(cfg, "solace", "exporterAuthScheme", "SOLACE_EXPORTER_AUTH_SCHEME", "none")
+	if err != nil {
+		return nil, nil, err
+	}
+	conf.ExporterAuth.Username, err = parseConfigStringOptional(cfg, "solace", "exporterAuthUsername", "SOLACE_EXPORTER_AUTH_USERNAME", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	conf.ExporterAuth.Password, err = parseConfigStringOptional(cfg, "solace", "exporterAuthPassword", "SOLACE_EXPORTER_AUTH_PASSWORD", "")
+	if err != nil {
+		return nil, nil, err
+	}
 	conf.ListenAddr, err = parseConfigString(cfg, "solace", "listenAddr", "SOLACE_LISTEN_ADDR")
 	if err != nil {
 		return nil, nil, err

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,0 +1,27 @@
+package web
+
+import (
+	"net/http"
+	"solace_exporter/internal/exporter"
+)
+
+func WrapWithAuth(handler http.Handler, authConf exporter.ExporterAuthConfig) http.Handler {
+	if (authConf.Scheme == "basic") && (len(authConf.Username) > 0) && (len(authConf.Password) > 0) {
+		return basicAuth(handler, authConf)
+	}
+	return handler
+}
+
+func basicAuth(h http.Handler, authConf exporter.ExporterAuthConfig) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != authConf.Username || p != authConf.Password {
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("unauthorized\n"))
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"solace_exporter/internal/exporter"
+	"strings"
+	"testing"
+)
+
+func newTestHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+}
+
+func TestWrapWithAuthNoAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler()
+
+	authConf := exporter.ExporterAuthConfig{
+		Scheme:   "none",
+		Username: "",
+		Password: "",
+	}
+
+	wrapped := WrapWithAuth(handler, authConf)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	if strings.TrimSpace(rr.Body.String()) != "ok" {
+		t.Errorf("expected body 'ok', got '%s'", rr.Body.String())
+	}
+}
+
+func TestWrapWithAuthBasicAuthSuccess(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler()
+
+	authConf := exporter.ExporterAuthConfig{
+		Scheme:   "basic",
+		Username: "admin",
+		Password: "secret",
+	}
+
+	wrapped := WrapWithAuth(handler, authConf)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("admin", "secret")
+
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	if strings.TrimSpace(rr.Body.String()) != "ok" {
+		t.Errorf("expected body 'ok', got '%s'", rr.Body.String())
+	}
+}
+
+func TestWrapWithAuthBasicAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler()
+
+	authConf := exporter.ExporterAuthConfig{
+		Scheme:   "basic",
+		Username: "admin",
+		Password: "secret",
+	}
+
+	wrapped := WrapWithAuth(handler, authConf)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("wrong", "creds")
+
+	rr := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rr.Code)
+	}
+
+	if rr.Header().Get("WWW-Authenticate") == "" {
+		t.Errorf("expected WWW-Authenticate header to be set")
+	}
+
+	if !strings.Contains(rr.Body.String(), "unauthorized") {
+		t.Errorf("expected body to contain 'unauthorized', got '%s'", rr.Body.String())
+	}
+}


### PR DESCRIPTION
- Introduce config parameters: exporterAuthScheme, exporterAuthUsername, exporterAuthPassword
- Add WrapWithAuth middleware to secure any http.Handler
- Apply authentication to all endpoints
- Add unit tests covering no auth, valid and invalid credentials
- Update README with configuration examples and usage