### PR TITLE
refactor: move MoreCookie & ExecuteResult to common types

### DIFF
--- a/internal/semp/getBridgeRemoteSemp1.go
+++ b/internal/semp/getBridgeRemoteSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,10 +42,7 @@ func (semp *Semp) GetBridgeRemoteSemp1(ch chan<- PrometheusMetric, vpnFilter str
 				} `xml:"bridge"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><bridge><bridge-name-pattern>" + itemFilter + "</bridge-name-pattern><vpn-name-pattern>" + vpnFilter + "</vpn-name-pattern></bridge></show></rpc>"
@@ -62,9 +59,15 @@ func (semp *Semp) GetBridgeRemoteSemp1(ch chan<- PrometheusMetric, vpnFilter str
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml BridgeRemoteSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 	ch <- semp.NewMetric(MetricDesc["Bridge"]["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue)
 	ch <- semp.NewMetric(MetricDesc["Bridge"]["bridges_max_num_total_bridges"], prometheus.CounterValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalBridgesValue)

--- a/internal/semp/getBridgeStatsSemp1.go
+++ b/internal/semp/getBridgeStatsSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,10 +99,7 @@ func (semp *Semp) GetBridgeStatsSemp1(ch chan<- PrometheusMetric, vpnFilter stri
 				} `xml:"bridge"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><bridge><bridge-name-pattern>" + itemFilter + "</bridge-name-pattern><vpn-name-pattern>" + vpnFilter + "</vpn-name-pattern><stats/></bridge></show></rpc>"
@@ -119,9 +116,15 @@ func (semp *Semp) GetBridgeStatsSemp1(ch chan<- PrometheusMetric, vpnFilter stri
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
 		bridgeName := bridge.BridgeName

--- a/internal/semp/getClientSemp1.go
+++ b/internal/semp/getClientSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 	"strings"
 
 	"github.com/go-kit/log/level"
@@ -27,18 +27,13 @@ func (semp *Semp) GetClientSemp1(ch chan<- PrometheusMetric, vpnFilter string, i
 				} `xml:"client"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
-	for nextRequest := "<rpc><show><client><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><connected/></client></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "ClientSemp1", page)
+	for command := "<rpc><show><client><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><connected/></client></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "ClientSemp1", page)
 		page++
 
 		if err != nil {
@@ -53,12 +48,18 @@ func (semp *Semp) GetClientSemp1(ch chan<- PrometheusMetric, vpnFilter string, i
 			_ = level.Error(semp.logger).Log("msg", "Can't decode ClientSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, client := range target.RPC.Show.Client.PrimaryVirtualRouter.Client {
 			clientIP := strings.Split(client.ClientAddress, ":")[0]

--- a/internal/semp/getClientSlowSubscriberSemp1.go
+++ b/internal/semp/getClientSlowSubscriberSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 	"strings"
 
 	"github.com/go-kit/log/level"
@@ -27,18 +27,13 @@ func (semp *Semp) GetClientSlowSubscriberSemp1(ch chan<- PrometheusMetric, vpnFi
 				} `xml:"client"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
-	for nextRequest := "<rpc><show><client><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><slow-subscriber/></client></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "ClientSlowSubscriberSemp1", page)
+	for command := "<rpc><show><client><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><slow-subscriber/></client></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "ClientSlowSubscriberSemp1", page)
 		page++
 
 		if err != nil {
@@ -55,12 +50,18 @@ func (semp *Semp) GetClientSlowSubscriberSemp1(ch chan<- PrometheusMetric, vpnFi
 			_ = level.Error(semp.logger).Log("msg", "Can't decode ClientSlowSubscriberSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 		const slowSubscriber float64 = 1.0
 
 		for _, client := range target.RPC.Show.Client.PrimaryVirtualRouter.Client {

--- a/internal/semp/getClusterLinksSemp1.go
+++ b/internal/semp/getClusterLinksSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,10 +32,7 @@ func (semp *Semp) GetClusterLinksSemp1(ch chan<- PrometheusMetric, clusterFilter
 				} `xml:"cluster"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><cluster><cluster-name-pattern>" + clusterFilter + "</cluster-name-pattern><link-name-pattern>" + linkFilter + "</link-name-pattern></cluster></show></rpc>"
@@ -52,9 +49,15 @@ func (semp *Semp) GetClusterLinksSemp1(ch chan<- PrometheusMetric, clusterFilter
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml ClusterLinksSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, cluster := range target.RPC.Show.Cluster.Clusters.Cluster {

--- a/internal/semp/getConfigSyncRouterSemp1.go
+++ b/internal/semp/getConfigSyncRouterSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,10 +31,7 @@ func (semp *Semp) GetConfigSyncRouterSemp1(ch chan<- PrometheusMetric) (float64,
 				} `xml:"config-sync"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><config-sync><database/><router/></config-sync></show></rpc>"
@@ -51,9 +48,15 @@ func (semp *Semp) GetConfigSyncRouterSemp1(ch chan<- PrometheusMetric) (float64,
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml ConfigSyncRouterSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {

--- a/internal/semp/getConfigSyncSemp1.go
+++ b/internal/semp/getConfigSyncSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,10 +21,7 @@ func (semp *Semp) GetConfigSyncSemp1(ch chan<- PrometheusMetric) (float64, error
 				} `xml:"config-sync"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><config-sync></config-sync></show></rpc>"
@@ -41,9 +38,15 @@ func (semp *Semp) GetConfigSyncSemp1(ch chan<- PrometheusMetric) (float64, error
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	ch <- semp.NewMetric(MetricDesc["ConfigSync"]["configsync_admin_state"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.ConfigSync.Status.AdminStatus, []string{"Shutdown", "Enabled"}))

--- a/internal/semp/getConfigSyncVpnSemp1.go
+++ b/internal/semp/getConfigSyncVpnSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,10 +31,7 @@ func (semp *Semp) GetConfigSyncVpnSemp1(ch chan<- PrometheusMetric, vpnFilter st
 				} `xml:"config-sync"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><config-sync><database/><message-vpn/><vpn-name>" + vpnFilter + "</vpn-name></config-sync></show></rpc>"
@@ -51,9 +48,15 @@ func (semp *Semp) GetConfigSyncVpnSemp1(ch chan<- PrometheusMetric, vpnFilter st
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {

--- a/internal/semp/getDiskSemp1.go
+++ b/internal/semp/getDiskSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 	"strconv"
 	"strings"
 
@@ -29,10 +29,7 @@ func (semp *Semp) GetDiskSemp1(ch chan<- PrometheusMetric) (float64, error) {
 				} `xml:"disk"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><disk><detail/></disk></show></rpc>"
@@ -49,9 +46,15 @@ func (semp *Semp) GetDiskSemp1(ch chan<- PrometheusMetric) (float64, error) {
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml DiskSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	blockSize := 1024.0

--- a/internal/semp/getHardwareSemp1.go
+++ b/internal/semp/getHardwareSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 	"strings"
 
 	"github.com/go-kit/log/level"
@@ -41,10 +41,7 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (float64, error) 
 				} `xml:"hardware"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><hardware><details/></hardware></show></rpc>"
@@ -61,9 +58,15 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (float64, error) 
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml HardwareSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	ch <- semp.NewMetric(MetricDesc["Hardware"]["operational_power_supplies"], prometheus.GaugeValue, target.RPC.Show.Hardware.PowerRedundancy.OperationalPowerSupplies)

--- a/internal/semp/getHealthSemp1.go
+++ b/internal/semp/getHealthSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,10 +31,7 @@ func (semp *Semp) GetHealthSemp1(ch chan<- PrometheusMetric) (float64, error) {
 				} `xml:"system"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><system><health/></system></show ></rpc>"
@@ -51,9 +48,15 @@ func (semp *Semp) GetHealthSemp1(ch chan<- PrometheusMetric) (float64, error) {
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	ch <- semp.NewMetric(MetricDesc["Health"]["system_disk_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMinimumValue/1e6)

--- a/internal/semp/getInterfaceHWSemp1.go
+++ b/internal/semp/getInterfaceHWSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -47,10 +47,7 @@ func (semp *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilte
 				} `xml:"interface"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><interface>"
@@ -73,9 +70,15 @@ func (semp *Semp) GetInterfaceHWSemp1(ch chan<- PrometheusMetric, interfaceFilte
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml InterfaceHWSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, intf := range target.RPC.Show.Interface.Interfaces.Interface {

--- a/internal/semp/getInterfaceSemp1.go
+++ b/internal/semp/getInterfaceSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,10 +28,7 @@ func (semp *Semp) GetInterfaceSemp1(ch chan<- PrometheusMetric, interfaceFilter 
 				} `xml:"interface"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><interface><phy-interface>" + interfaceFilter + "</phy-interface></interface></show></rpc>"
@@ -48,9 +45,15 @@ func (semp *Semp) GetInterfaceSemp1(ch chan<- PrometheusMetric, interfaceFilter 
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml InterfaceSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, intf := range target.RPC.Show.Interface.Interfaces.Interface {

--- a/internal/semp/getMemorySemp1.go
+++ b/internal/semp/getMemorySemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,10 +25,7 @@ func (semp *Semp) GetMemorySemp1(ch chan<- PrometheusMetric) (float64, error) {
 				} `xml:"memory"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><memory/></show></rpc>"
@@ -45,9 +42,15 @@ func (semp *Semp) GetMemorySemp1(ch chan<- PrometheusMetric) (float64, error) {
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml MemorySemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	ch <- semp.NewMetric(MetricDesc["Memory"]["system_memory_physical_usage_percent"], prometheus.GaugeValue, target.RPC.Show.Memory.PhysicalUsagePercent)

--- a/internal/semp/getQueueDetailsSemp1.go
+++ b/internal/semp/getQueueDetailsSemp1.go
@@ -2,8 +2,8 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
 	"math"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,19 +32,14 @@ func (semp *Semp) GetQueueDetailsSemp1(ch chan<- PrometheusMetric, vpnFilter str
 				} `xml:"queue"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var lastQueueName = ""
 	var page = 1
-	for nextRequest := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><detail/><count/><num-elements>100</num-elements></queue></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "QueueDetailsSemp1", page)
+	for command := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><detail/><count/><num-elements>100</num-elements></queue></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "QueueDetailsSemp1", page)
 		page++
 
 		if err != nil {
@@ -59,12 +54,18 @@ func (semp *Semp) GetQueueDetailsSemp1(ch chan<- PrometheusMetric, vpnFilter str
 			_ = level.Error(semp.logger).Log("msg", "Can't decode QueueDetailsSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "Can't scrape QueueDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, queue := range target.RPC.Show.Queue.Queues.Queue {
 			queueKey := queue.Info.MsgVpnName + "___" + queue.QueueName

--- a/internal/semp/getQueueRatesSemp1.go
+++ b/internal/semp/getQueueRatesSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,19 +39,14 @@ func (semp *Semp) GetQueueRatesSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 				} `xml:"queue"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
 	var lastQueueName = ""
-	for nextRequest := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><rates/><count/><num-elements>100</num-elements></queue></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "QueueRatesSemp1", page)
+	for command := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><rates/><count/><num-elements>100</num-elements></queue></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "QueueRatesSemp1", page)
 		page++
 
 		if err != nil {
@@ -66,12 +61,18 @@ func (semp *Semp) GetQueueRatesSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 			_ = level.Error(semp.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, queue := range target.RPC.Show.Queue.Queues.Queue {
 			queueKey := queue.Info.MsgVpnName + "___" + queue.QueueName

--- a/internal/semp/getQueueStatsSemp1.go
+++ b/internal/semp/getQueueStatsSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,19 +46,14 @@ func (semp *Semp) GetQueueStatsSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 				} `xml:"queue"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
 	var lastQueueName = ""
-	for nextRequest := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><stats/><count/><num-elements>100</num-elements></queue></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "QueueStatsSemp1", page)
+	for command := "<rpc><show><queue><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><stats/><count/><num-elements>100</num-elements></queue></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "QueueStatsSemp1", page)
 		page++
 
 		if err != nil {
@@ -73,14 +68,20 @@ func (semp *Semp) GetQueueStatsSemp1(ch chan<- PrometheusMetric, vpnFilter strin
 			_ = level.Error(semp.logger).Log("msg", "Can't decode QueueStatsSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
 		_ = level.Debug(semp.logger).Log("msg", "Result of QueueStatsSemp1", "results", len(target.RPC.Show.Queue.Queues.Queue), "page", page-1)
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 		for _, queue := range target.RPC.Show.Queue.Queues.Queue {
 			queueKey := queue.Info.MsgVpnName + "___" + queue.QueueName
 			if queueKey == lastQueueName {

--- a/internal/semp/getRaidSemp1.go
+++ b/internal/semp/getRaidSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,10 +30,7 @@ func (semp *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (float64, error) {
 				} `xml:"disk"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><disk></disk></show></rpc>"
@@ -50,9 +47,15 @@ func (semp *Semp) GetRaidSemp1(ch chan<- PrometheusMetric) (float64, error) {
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml GetRaidSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, disk := range target.RPC.Show.Disk.DiskInfos.InternalDisks.DiskInfo {

--- a/internal/semp/getRdpInfoSemp1.go
+++ b/internal/semp/getRdpInfoSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,18 +43,13 @@ func (semp *Semp) GetRdpInfoSemp1(ch chan<- PrometheusMetric, vpnFilter string, 
 				} `xml:"message-vpn"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 	var page = 1
 	var lastRdpName = ""
-	for nextRequest := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><rest></rest><rest-delivery-point></rest-delivery-point><rdp-name>" + itemFilter + "</rdp-name></message-vpn></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "RdpInfoSemp1", page)
+	for command := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><rest></rest><rest-delivery-point></rest-delivery-point><rdp-name>" + itemFilter + "</rdp-name></message-vpn></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "RdpInfoSemp1", page)
 		page++
 		if err != nil {
 			_ = level.Error(semp.logger).Log("msg", "Can't scrape RdpInfoSemp1", "err", err, "broker", semp.brokerURI)
@@ -68,12 +63,18 @@ func (semp *Semp) GetRdpInfoSemp1(ch chan<- PrometheusMetric, vpnFilter string, 
 			_ = level.Error(semp.logger).Log("msg", "Can't decode Xml RdpInfoSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 		_ = level.Debug(semp.logger).Log("msg", "Result of RdpInfoSemp1", "results", len(target.RPC.Show.MessageVpn.Rest.RestDeliveryPoints.RestDeliveryPoint), "page", page-1)
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		rdpTotals := target.RPC.Show.MessageVpn.Rest.RestDeliveryPoints.Totals
 		ch <- semp.NewMetric(MetricDesc["RdpTotals"]["total_rest_delivery_points_up"], prometheus.CounterValue, rdpTotals.TotalRdpsUp)

--- a/internal/semp/getRedundancySemp1.go
+++ b/internal/semp/getRedundancySemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,10 +41,7 @@ func (semp *Semp) GetRedundancySemp1(ch chan<- PrometheusMetric) (float64, error
 				} `xml:"redundancy"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><redundancy/></show></rpc>"
@@ -61,9 +58,15 @@ func (semp *Semp) GetRedundancySemp1(ch chan<- PrometheusMetric) (float64, error
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml RedundancySemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	mateRouterName := "" + target.RPC.Show.Red.MateRouterName

--- a/internal/semp/getReplicationStatsSemp1.go
+++ b/internal/semp/getReplicationStatsSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,10 +65,7 @@ func (semp *Semp) GetReplicationStatsSemp1(ch chan<- PrometheusMetric) (float64,
 				} `xml:"replication"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><replication><stats/></replication></show></rpc>"
@@ -85,9 +82,15 @@ func (semp *Semp) GetReplicationStatsSemp1(ch chan<- PrometheusMetric) (float64,
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml ReplicationStatsSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	replMateName := "" + target.RPC.Show.Repl.Mate.Name

--- a/internal/semp/getRestConsumerStatsSemp1.go
+++ b/internal/semp/getRestConsumerStatsSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 	"strconv"
 
 	"github.com/go-kit/log/level"
@@ -35,20 +35,15 @@ func (semp *Semp) GetRestConsumerStatsSemp1(ch chan<- PrometheusMetric, vpnFilte
 				} `xml:"message-vpn"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
 	var lastConsumerName = ""
 	numOfElementsPerRequest := int64(100)
-	for nextRequest := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><rest></rest><rest-consumer></rest-consumer><rest-consumer-name>" + itemFilter + "</rest-consumer-name><stats></stats><count/><num-elements>" + strconv.FormatInt(numOfElementsPerRequest, 10) + "</num-elements></message-vpn></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "RestConsumerStatsSemp1", page)
+	for command := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><rest></rest><rest-consumer></rest-consumer><rest-consumer-name>" + itemFilter + "</rest-consumer-name><stats></stats><count/><num-elements>" + strconv.FormatInt(numOfElementsPerRequest, 10) + "</num-elements></message-vpn></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "RestConsumerStatsSemp1", page)
 		page++
 
 		if err != nil {
@@ -63,14 +58,20 @@ func (semp *Semp) GetRestConsumerStatsSemp1(ch chan<- PrometheusMetric, vpnFilte
 			_ = level.Error(semp.logger).Log("msg", "Can't decode Xml RestConsumerStatsSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
 		_ = level.Debug(semp.logger).Log("msg", "Result of RestConsumerStatsSemp1", "results", len(target.RPC.Show.MessageVpn.RestConsumerInfo.StatsInfo), "page", page-1)
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, consumerStats := range target.RPC.Show.MessageVpn.RestConsumerInfo.StatsInfo {
 			consumerKey := consumerStats.MsgVpnName + "___" + consumerStats.RdpName + "___" + consumerStats.RestConsumerName

--- a/internal/semp/getStorageElementSemp1.go
+++ b/internal/semp/getStorageElementSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,10 +26,7 @@ func (semp *Semp) GetStorageElementSemp1(ch chan<- PrometheusMetric, storageElem
 				} `xml:"storage-element"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><storage-element><pattern>" + storageElementFilter + "</pattern></storage-element></show></rpc>"
@@ -46,9 +43,15 @@ func (semp *Semp) GetStorageElementSemp1(ch chan<- PrometheusMetric, storageElem
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml StorageElementSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	blockSize := 1024.0

--- a/internal/semp/getTopicEndpointDetailsSemp1.go
+++ b/internal/semp/getTopicEndpointDetailsSemp1.go
@@ -2,8 +2,8 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
 	"math"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,19 +31,14 @@ func (semp *Semp) GetTopicEndpointDetailsSemp1(ch chan<- PrometheusMetric, vpnFi
 				} `xml:"topic-endpoint"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
 	var lastTopicEndpointName = ""
-	for nextRequest := "<rpc><show><topic-endpoint><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><detail/><count/><num-elements>100</num-elements></topic-endpoint></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "TopicEndpointDetailsSemp1", page)
+	for command := "<rpc><show><topic-endpoint><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><detail/><count/><num-elements>100</num-elements></topic-endpoint></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "TopicEndpointDetailsSemp1", page)
 		page++
 
 		if err != nil {
@@ -58,12 +53,18 @@ func (semp *Semp) GetTopicEndpointDetailsSemp1(ch chan<- PrometheusMetric, vpnFi
 			_ = level.Error(semp.logger).Log("msg", "Can't decode TopicEndpointDetailsSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "Can't scrape TopicEndpointDetailsSemp1", "err", err, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, topicEndpoint := range target.RPC.Show.TopicEndpoint.TopicEndpoints.TopicEndpoint {
 			topicEndpointKey := topicEndpoint.Info.MsgVpnName + "___" + topicEndpoint.TopicEndpointName

--- a/internal/semp/getTopicEndpointRatesSemp1.go
+++ b/internal/semp/getTopicEndpointRatesSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,19 +39,14 @@ func (semp *Semp) GetTopicEndpointRatesSemp1(ch chan<- PrometheusMetric, vpnFilt
 				} `xml:"topic-endpoint"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		MoreCookie struct {
-			RPC string `xml:",innerxml"`
-		} `xml:"more-cookie"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	var page = 1
 	var lastTopicEndpointName = ""
-	for nextRequest := "<rpc><show><topic-endpoint><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><rates/><count/><num-elements>100</num-elements></topic-endpoint></show></rpc>"; nextRequest != ""; {
-		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", nextRequest, "TopicEndpointRatesSemp1", page)
+	for command := "<rpc><show><topic-endpoint><name>" + itemFilter + "</name><vpn-name>" + vpnFilter + "</vpn-name><rates/><count/><num-elements>100</num-elements></topic-endpoint></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "TopicEndpointRatesSemp1", page)
 		page++
 
 		if err != nil {
@@ -66,12 +61,18 @@ func (semp *Semp) GetTopicEndpointRatesSemp1(ch chan<- PrometheusMetric, vpnFilt
 			_ = level.Error(semp.logger).Log("msg", "Can't decode TopicEndpointRatesSemp1", "err", err, "broker", semp.brokerURI)
 			return 0, err
 		}
-		if target.ExecuteResult.Result != "ok" {
-			_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
-			return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+		if err := target.ExecuteResult.OK(); err != nil {
+			_ = level.Error(semp.logger).Log(
+				"msg", "unexpected result",
+				"command", command,
+				"result", target.ExecuteResult.Result,
+				"reason", target.ExecuteResult.Reason,
+				"broker", semp.brokerURI,
+			)
+			return 0, err
 		}
 
-		nextRequest = target.MoreCookie.RPC
+		command = target.MoreCookie.RPC
 
 		for _, topicEndpoint := range target.RPC.Show.TopicEndpoint.TopicEndpoints.TopicEndpoint {
 			topicEndpointKey := topicEndpoint.Info.MsgVpnName + "___" + topicEndpoint.TopicEndpointName

--- a/internal/semp/getVersionSemp1.go
+++ b/internal/semp/getVersionSemp1.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"solace_exporter/internal/semp/types"
 	"strconv"
 	"strings"
 
@@ -30,10 +31,7 @@ func (semp *Semp) GetVersionSemp1(ch chan<- PrometheusMetric) (float64, error) {
 				} `xml:"version"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><version/></show></rpc>"

--- a/internal/semp/getVpnReplicationSemp1.go
+++ b/internal/semp/getVpnReplicationSemp1.go
@@ -2,7 +2,7 @@ package semp
 
 import (
 	"encoding/xml"
-	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,10 +27,7 @@ func (semp *Semp) GetVpnReplicationSemp1(ch chan<- PrometheusMetric, vpnFilter s
 				} `xml:"message-vpn"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><replication/></message-vpn></show></rpc>"
@@ -47,9 +44,15 @@ func (semp *Semp) GetVpnReplicationSemp1(ch chan<- PrometheusMetric, vpnFilter s
 		_ = level.Error(semp.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err, "broker", semp.brokerURI)
 		return 0, err
 	}
-	if target.ExecuteResult.Result != "ok" {
-		_ = level.Error(semp.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "reason", target.ExecuteResult.Reason, "broker", semp.brokerURI)
-		return 0, errors.New("unexpected result: " + target.ExecuteResult.Reason + ". see log for further details")
+	if err := target.ExecuteResult.OK(); err != nil {
+		_ = level.Error(semp.logger).Log(
+			"msg", "unexpected result",
+			"command", command,
+			"result", target.ExecuteResult.Result,
+			"reason", target.ExecuteResult.Reason,
+			"broker", semp.brokerURI,
+		)
+		return 0, err
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Replication.MessageVpns.MessageVpn {

--- a/internal/semp/getVpnSemp1.go
+++ b/internal/semp/getVpnSemp1.go
@@ -3,6 +3,7 @@ package semp
 import (
 	"encoding/xml"
 	"errors"
+	"solace_exporter/internal/semp/types"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,10 +32,7 @@ func (semp *Semp) GetVpnSemp1(ch chan<- PrometheusMetric, vpnFilter string) (flo
 				} `xml:"message-vpn"`
 			} `xml:"show"`
 		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-			Reason string `xml:"reason,attr"`
-		} `xml:"execute-result"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
 	}
 
 	command := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name></message-vpn></show></rpc>"

--- a/internal/semp/types/common.go
+++ b/internal/semp/types/common.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"fmt"
+)
+
+type ExecuteResult struct {
+	Result string `xml:"code,attr"`
+	Reason string `xml:"reason,attr"`
+}
+
+func (e ExecuteResult) OK() error {
+	if e.Result == "ok" {
+		return nil
+	}
+	return fmt.Errorf("unexpected result: %s", e.Reason)
+}
+
+type MoreCookie struct {
+	RPC string `xml:",innerxml"`
+}


### PR DESCRIPTION
## Description
This PR extracts the MoreCookie and ExecuteResult types from individual SEMP metric classes into a central `types/common.go` file.

## Changes include
* MoreCookie and ExecuteResult are now shared types used across all SEMP metric classes.
* All SEMP metric classes have been updated to import and use the new common types.

## Benefits
* Reduces duplication and centralizes shared types.
* Prepares the codebase for consistent handling of SEMP responses.
* Makes future refactoring and addition of shared logic easier.