### PR TITLE
remove duplicate build target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ test-coverage: ## Run tests with coverage
 	@go test -short -coverprofile reports/cover.out ${PKG_LIST}
 	@go tool cover -html reports/cover.out -o reports/cover.html
 
-build: dep ## Build the binary file
-	@go build -a -ldflags '-s -w -extldflags "-static"' -o solace_prometheus_exporter
-
 build: ## Build binary
 	@echo "Building $(BINARY_NAME)..."
 	@go build -a -ldflags '-s -w -extldflags "-static"' -o bin/$(BINARY_NAME) $(CMD_PATH)


### PR DESCRIPTION
The Makefile defined the build target twice, which caused Make to override the first definition and emit warnings during make build:
```
Makefile:26: warning: overriding commands for target `build'
Makefile:23: warning: ignoring old commands for target `build'
```

Keeping a single build target avoids confusion and makes the build behavior deterministic.
