### PR TITLE
feat: allow issuer in OAuth authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,11 @@ oAuthClientID=your-client-id
 # OAuth Client Secret to fetch tokens from.
 oAuthClientSecret=your-client-secret
 
+# OAuth Client Secret to fetch tokens from (optional)
+# See https://docs.solace.com/Security/Client-Authentication-Overview.htm#provisioning-configuration-information-3
+# And https://community.solace.com/t/oauth-2-0-authentication-for-solace-cloud-rest-endpoints/1742/2
+oAuthIssuer=optional-issuer
+
 # Timeout for HTTP scrape requests to Solace broker.
 timeout = 5s
 
@@ -398,6 +403,7 @@ SOLACE_PASSWORD=admin
 SOLACE_OAUTH_TOKEN_URL=https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token
 SOLACE_OAUTH_CLIENT_ID=your-client-id
 SOLACE_OAUTH_CLIENT_SECRET=your-client-secret
+SOLACE_OAUTH_ISSUER=optional-issuer
 SOLACE_TIMEOUT=5s
 SOLACE_SSL_VERIFY=false
 SOLACE_EXPORTER_AUTH_SCHEME=basic

--- a/internal/exporter/auth.go
+++ b/internal/exporter/auth.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"time"
 
@@ -30,7 +31,7 @@ func (conf *Config) setAuthHeader() (func(*http.Request), error) {
 			return nil, err
 		}
 		return func(request *http.Request) {
-			request.Header.Set("Authorization", "Bearer "+token)
+			request.Header.Set("Authorization", "Bearer "+conf.issuerPrefixedToken(token))
 		}, nil
 	}
 
@@ -63,4 +64,13 @@ func (conf *Config) getOAuthToken() (string, error) {
 	conf.oAuthTokenExpiry = token.Expiry
 
 	return conf.oAuthAccessToken, nil
+}
+
+func (conf *Config) issuerPrefixedToken(token string) string {
+	if conf.OAuthIssuer == "" {
+		return token
+	}
+	return "~" +
+		base64.StdEncoding.EncodeToString([]byte(conf.OAuthIssuer)) +
+		"~" + token
 }

--- a/internal/exporter/config.struct.go
+++ b/internal/exporter/config.struct.go
@@ -42,6 +42,7 @@ type Config struct {
 	OAuthClientID           string
 	OAuthClientSecret       string
 	OAuthClientScope        string
+	OAuthIssuer             string
 	oAuthAccessToken        string
 	oAuthTokenExpiry        time.Time
 	authType                AuthType
@@ -167,6 +168,10 @@ func ParseConfig(configFile string) (map[string][]DataSource, *Config, error) {
 		return nil, nil, err
 	}
 	conf.OAuthClientScope, err = parseConfigStringOptional(cfg, "solace", "oAuthClientScope", "SOLACE_OAUTH_CLIENT_SCOPE", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	conf.OAuthIssuer, err = parseConfigStringOptional(cfg, "solace", "oAuthIssuer", "SOLACE_OAUTH_ISSUER", "")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR adds the possibility to set an OAuth issuer for selecting a specific OAuth profile via the Authorization header.

**Details**
- prepend base64 encoded issuer to auth token
- No functional changes to the OAuth flow
- Fully backwards compatible

**Release**
This change should be released with a **new tag**, as it affects authentication header construction and is relevant for users relying on OAuth profile selection.