### PR TITLE
Add support for providing SEMP Basic Auth credentials via HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,32 @@ This allows you to overwrite the parameters, which are in the ini-config file / 
 
 This provides you a single exporter for all your OnPrem brokers.
 
-Security: Only use this feature with HTTPS.
+#### Providing SEMP Basic Auth Credentials
+
+Credentials for accessing the Solace broker can be provided in three ways (in order of priority):
+
+1. **HTTP Headers** (recommended for security):
+   - `X-Solace-Username`: The username for SEMP authentication
+   - `X-Solace-Password`: The password for SEMP authentication
+
+   Example using curl:
+   ```bash
+   curl -H "X-Solace-Username: admin" -H "X-Solace-Password: admin" \
+     "https://your-exporter:9628/solace?m.Version=*|*&scrapeURI=https://your-broker:943"
+   ```
+
+2. **Query Parameters**:
+   - `username`: The username for SEMP authentication
+   - `password`: The password for SEMP authentication
+
+   Example:
+   ```
+   https://your-exporter:9628/solace?m.Version=*|*&scrapeURI=https://your-broker:943&username=admin&password=admin
+   ```
+
+3. **Config File / Environment Variables** (fallback):
+   If no credentials are provided via headers or query parameters, the exporter uses the values from the config file or environment variables (`SOLACE_USERNAME` / `SOLACE_PASSWORD`).
+   
 
 #### Sample prometheus config
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"solace_exporter/internal/exporter"
+	"solace_exporter/internal/web"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/promlog"
+	"github.com/prometheus/common/promlog/flag"
+	promVersion "github.com/prometheus/common/version"
+	"golang.org/x/sync/semaphore"
+)
+
+func logDataSource(dataSources []exporter.DataSource) string {
+	dS := make([]string, len(dataSources))
+	for index, dataSource := range dataSources {
+		dS[index] = dataSource.String()
+	}
+	return strings.Join(dS, "&")
+}
+
+func main() {
+	kingpin.HelpFlag.Short('h')
+
+	promlogConfig := promlog.Config{
+		Level:  &promlog.AllowedLevel{},
+		Format: &promlog.AllowedFormat{},
+	}
+	promlogConfig.Level.Set("info")
+	promlogConfig.Format.Set("logfmt")
+	flag.AddFlags(kingpin.CommandLine, &promlogConfig)
+
+	configFile := kingpin.Flag(
+		"config-file",
+		"Path and name of ini file with configuration settings. See sample file solace_prometheus_exporter.ini.",
+	).String()
+	kingpin.Parse()
+
+	logger := promlog.New(&promlogConfig)
+
+	endpoints, conf, err := exporter.ParseConfig(*configFile)
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		os.Exit(1)
+	}
+
+	level.Info(logger).Log("msg", "Starting solace_prometheus_exporter")
+	level.Info(logger).Log("msg", "Build context", "context", promVersion.BuildContext())
+
+	level.Info(logger).Log("msg", "Scraping",
+		"listenAddr", conf.GetListenURI(),
+		"scrapeURI", conf.ScrapeURI,
+		"username", conf.Username,
+		"sslVerify", conf.SslVerify,
+		"timeout", conf.Timeout)
+
+	// Configure endpoints
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		doHandle(w, r, nil, *conf, logger)
+	})
+
+	// A broker has only max 10 semp connections that can be served in parallel.
+	var sempConnections = semaphore.NewWeighted(conf.ParallelSempConnections)
+	declareHandlerFromConfig := func(urlPath string, dataSource []exporter.DataSource) {
+		_ = level.Info(logger).Log("msg", "Register handler from config", "handler", "/"+urlPath, "dataSource", logDataSource(dataSource))
+
+		if conf.PrefetchInterval.Seconds() > 0 {
+			var asyncFetcher = exporter.NewAsyncFetcher(urlPath, dataSource, *conf, logger, sempConnections)
+			http.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
+				doHandleAsync(w, r, asyncFetcher)
+			})
+		} else {
+			http.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
+				doHandle(w, r, dataSource, *conf, logger)
+			})
+		}
+	}
+	for urlPath, dataSource := range endpoints {
+		declareHandlerFromConfig(urlPath, dataSource)
+	}
+
+	http.HandleFunc("/solace", func(w http.ResponseWriter, r *http.Request) {
+		var err = r.ParseForm()
+		if err != nil {
+			level.Error(logger).Log("msg", "Can not parse the request parameter", "err", err)
+			return
+		}
+
+		var dataSource []exporter.DataSource
+		for key, values := range r.Form {
+			if strings.HasPrefix(key, "m.") {
+				for _, value := range values {
+					parts := strings.Split(value, "|")
+					if len(parts) < 2 {
+						level.Error(logger).Log("msg", "One or two | expected. Use VPN wildcard | Item wildcard | Optional metric filter for v2 apis", "key", key, "value", value)
+					} else {
+						var metricFilter []string
+						if len(parts) == 3 && len(strings.TrimSpace(parts[2])) > 0 {
+							metricFilter = strings.Split(parts[2], ",")
+						}
+
+						dataSource = append(dataSource, exporter.DataSource{
+							Name:         strings.TrimPrefix(key, "m."),
+							VpnFilter:    parts[0],
+							ItemFilter:   parts[1],
+							MetricFilter: metricFilter,
+						})
+					}
+				}
+			}
+		}
+
+		doHandle(w, r, dataSource, *conf, logger)
+	})
+
+	endpointViews := make([]web.EndpointView, 0, len(endpoints))
+
+	for urlPath, dataSources := range endpoints {
+		endpointViews = append(endpointViews, web.EndpointView{
+			Path: urlPath,
+			Meta: logDataSource(dataSources),
+		})
+	}
+
+	handler, err := web.NewHandler(web.TemplateData{
+		IsHWBroker: conf.IsHWBroker,
+		Endpoints:  endpointViews,
+	})
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+	}
+
+	http.Handle("/", web.WrapWithAuth(handler, conf.ExporterAuth))
+
+	// start server
+	if conf.EnableTLS {
+		exporter.ListenAndServeTLS(*conf)
+	} else {
+		server := &http.Server{
+			Addr:              conf.ListenAddr,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+
+		if err := server.ListenAndServe(); err != nil {
+			level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
+			os.Exit(2)
+		}
+	}
+}
+
+func doHandleAsync(w http.ResponseWriter, r *http.Request, asyncFetcher *exporter.AsyncFetcher) string {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(asyncFetcher)
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	handler.ServeHTTP(w, r)
+
+	return w.Header().Get("status")
+}
+
+func doHandle(w http.ResponseWriter, r *http.Request, dataSource []exporter.DataSource, conf exporter.Config, logger log.Logger) string {
+	var handler http.Handler
+	if dataSource == nil {
+		handler = promhttp.Handler()
+	} else {
+		// Exporter for endpoint
+		username := r.Header.Get("X-Solace-Username")
+		password := r.Header.Get("X-Solace-Password")
+
+		// Fall back to query parameters if headers not provided
+		if len(username) == 0 {
+			username = r.FormValue("username")
+		}
+		if len(password) == 0 {
+			password = r.FormValue("password")
+		}
+
+		scrapeURI := r.FormValue("scrapeURI")
+		timeout := r.FormValue("timeout")
+		if len(username) > 0 {
+			conf.Username = username
+		}
+		if len(password) > 0 {
+			conf.Password = password
+		}
+		if len(scrapeURI) > 0 {
+			conf.ScrapeURI = scrapeURI
+		}
+		if len(timeout) > 0 {
+			var err error
+			conf.Timeout, err = time.ParseDuration(timeout)
+			if err != nil {
+				level.Error(logger).Log("msg", "Per HTTP given timeout parameter is not valid", "err", err, "timeout", timeout)
+			}
+		}
+
+		level.Info(logger).Log("msg", "handle http request", "dataSource", logDataSource(dataSource), "scrapeURI", conf.ScrapeURI)
+
+		exp := exporter.NewExporter(logger, &conf, &dataSource)
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(exp)
+		handler = promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	}
+	securedHandler := web.WrapWithAuth(handler, conf.ExporterAuth)
+
+	securedHandler.ServeHTTP(w, r)
+	return w.Header().Get("status")
+}


### PR DESCRIPTION
- Add support for SEMP credentials via HTTP headers (`X-Solace-Username`, `X-Solace-Password`)
- Implement credential priority: HTTP headers → query parameters → config/env vars
- Update documentation with authentication methods and examples

Feature Request: # https://github.com/solacecommunity/solace-prometheus-exporter/issues/171

### Changes

**Authentication Enhancement (`main.go`):**
- Added support for `X-Solace-Username` and `X-Solace-Password` HTTP headers
- Headers take priority over query parameters for improved security
- Maintains backward compatibility with existing query parameter method

**Documentation (`README.md`):**
- Documented all three credential methods with priority order
- Added curl example for header-based authentication
- Clarified fallback behavior to config file/environment variables