### PR TITLE
Enhancement: implemented SEMP v1 scraping for MQTT sessions

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -109,6 +109,7 @@ Each parameter key must be a **scrape target** (see list below) prefixed by `m.`
 | VpnReplication                        | yes        | no          | no             | dont harm broker                                                      | show message-vpn vpnFilter replication                                             | software, appliance |
 | VpnSpool                              | yes        | no          | no             | dont harm broker                                                      | show message-spool message-vpn vpnFilter                                           | software, appliance |
 | VpnStats                              | yes        | no          | no             | has a very small performance down site                                | show message-vpn vpnFilter stats                                                   | software, appliance |
+| MqttSession                           | yes        | yes         | no             | may harm broker if many mqtt sessions                                 | show message-vpn vpnFilter mqtt mqtt-session itemFilter count 100 (paged)          | software, appliance |
 
 ### ⚠️ Metric Collisions
 There are metrics that may be provided by multiple endpoints. But not with the same labels. Avoid using these simultaneously. Otherwise it will cause Prometheus errors.

--- a/internal/exporter/exporter.collect.go
+++ b/internal/exporter/exporter.collect.go
@@ -159,6 +159,8 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 			up, err = e.semp.GetRdpStatsSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
 		case "RdpInfo", "RdpInfoV1":
 			up, err = e.semp.GetRdpInfoSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
+		case "MqttSession":
+			up, err = e.semp.GetMqttSessionSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter)
 		default:
 			up = 0
 			err = errors.New("Unknown scrape target: \"" + dataSource.Name + "\". Please check documentation for valid targets.")

--- a/internal/semp/getMqttSessionSemp1.go
+++ b/internal/semp/getMqttSessionSemp1.go
@@ -3,21 +3,10 @@ package semp
 import (
 	"encoding/xml"
 	"solace_exporter/internal/semp/types"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Kleine Hilfsfunktion, um Solace "yes"/"no" oder "true"/"false" in 1.0/0.0 umzuwandeln
-func boolToFloat(val string) float64 {
-	v := strings.ToLower(strings.TrimSpace(val))
-	if v == "yes" || v == "true" || v == "1" {
-		return 1.0
-	}
-	return 0.0
-}
-
-// GetMqttSessionSemp1 holt Details zu MQTT-Sessions inklusive Flags
 func (semp *Semp) GetMqttSessionSemp1(ch chan<- PrometheusMetric, vpnFilter string, itemFilter string) (float64, error) {
 	type Data struct {
 		RPC struct {

--- a/internal/semp/getMqttSessionSemp1.go
+++ b/internal/semp/getMqttSessionSemp1.go
@@ -1,0 +1,98 @@
+package semp
+
+import (
+	"encoding/xml"
+	"solace_exporter/internal/semp/types"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Kleine Hilfsfunktion, um Solace "yes"/"no" oder "true"/"false" in 1.0/0.0 umzuwandeln
+func boolToFloat(val string) float64 {
+	v := strings.ToLower(strings.TrimSpace(val))
+	if v == "yes" || v == "true" || v == "1" {
+		return 1.0
+	}
+	return 0.0
+}
+
+// GetMqttSessionSemp1 holt Details zu MQTT-Sessions inklusive Flags
+func (semp *Semp) GetMqttSessionSemp1(ch chan<- PrometheusMetric, vpnFilter string, itemFilter string) (float64, error) {
+	type Data struct {
+		RPC struct {
+			Show struct {
+				MessageVpn struct {
+					Mqtt struct {
+						MqttSessions struct {
+							MqttSession []struct {
+								ClientId         string  `xml:"client-id"`
+								Owner            string  `xml:"owner"`
+								MsgVpnName       string  `xml:"message-vpn"`
+								NumSubscriptions float64 `xml:"num-subscriptions"`
+								Enabled          string  `xml:"enabled"`
+								Clean            string  `xml:"clean"`
+								Durable          string  `xml:"durable"`
+								Uptime           struct {
+									Days  float64 `xml:"days"`
+									Hours float64 `xml:"hours"`
+									Mins  float64 `xml:"mins"`
+									Secs  float64 `xml:"secs"`
+								} `xml:"uptime"`
+							} `xml:"mqtt-session"`
+						} `xml:"mqtt-sessions"`
+					} `xml:"mqtt"`
+				} `xml:"message-vpn"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		MoreCookie    types.MoreCookie    `xml:"more-cookie,omitempty"`
+		ExecuteResult types.ExecuteResult `xml:"execute-result"`
+	}
+
+	var lastSessionKey = ""
+	var page = 1
+
+	for command := "<rpc><show><message-vpn><vpn-name>" + vpnFilter + "</vpn-name><mqtt/><mqtt-session/><client-id-pattern>" + itemFilter + "</client-id-pattern><count/><num-elements>100</num-elements></message-vpn></show></rpc>"; command != ""; {
+		body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml", command, "MqttSessionSemp1", page)
+		page++
+
+		if err != nil {
+			semp.logger.Error("Can't scrape MqttSessionSemp1", "err", err, "broker", semp.brokerURI)
+			return -1, err
+		}
+
+		decoder := xml.NewDecoder(body)
+		var target Data
+		err = decoder.Decode(&target)
+		if err != nil {
+			semp.logger.Error("Can't decode MqttSessionSemp1", "err", err, "broker", semp.brokerURI)
+			_ = body.Close()
+			return 0, err
+		}
+
+		if err := target.ExecuteResult.OK(); err != nil {
+			semp.logger.Error("unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", semp.brokerURI)
+			_ = body.Close()
+			return 0, err
+		}
+
+		command = target.MoreCookie.RPC
+
+		for _, session := range target.RPC.Show.MessageVpn.Mqtt.MqttSessions.MqttSession {
+			sessionKey := session.MsgVpnName + "___" + session.ClientId
+			if sessionKey == lastSessionKey {
+				continue
+			}
+			lastSessionKey = sessionKey
+
+			uptimeSeconds := (session.Uptime.Days * 86400) + (session.Uptime.Hours * 3600) + (session.Uptime.Mins * 60) + session.Uptime.Secs
+
+			ch <- semp.NewMetric(MetricDesc["MqttSession"]["mqtt_session_info"], prometheus.GaugeValue, 1.0, session.MsgVpnName, session.ClientId, session.Owner, session.Clean, session.Durable, session.Enabled)
+			ch <- semp.NewMetric(MetricDesc["MqttSession"]["mqtt_session_subscriptions"], prometheus.GaugeValue, session.NumSubscriptions, session.MsgVpnName, session.ClientId, session.Owner)
+			ch <- semp.NewMetric(MetricDesc["MqttSession"]["mqtt_session_uptime_seconds"], prometheus.GaugeValue, uptimeSeconds, session.MsgVpnName, session.ClientId, session.Owner)
+		}
+		_ = body.Close()
+	}
+
+	return 1, nil
+}

--- a/internal/semp/metricDesc.go
+++ b/internal/semp/metricDesc.go
@@ -38,6 +38,8 @@ var (
 	variableLabelsRdpInfo            = []string{"vpn_name", "rdp_name"}
 	variableLabelsRdpStats           = []string{"vpn_name", "rdp_name"}
 	variableLabelsSpool              = []string{"partition"}
+	variableLabelsMqttSession        = []string{"vpn_name", "client_id", "owner"}
+	variableLabelsMqttSessionInfo    = []string{"vpn_name", "client_id", "owner", "clean", "durable", "enabled"}
 )
 
 var QueueStats = Descriptions{
@@ -678,5 +680,10 @@ var MetricDesc = map[string]Descriptions{
 		"total_rest_consumer_outgoing_connections_configured": NewSemDesc("rdp_total_rest_consumer_outgoing_connections_configured", NoSempV2Ready, "The total number of configured outgoing REST consumer connections.", nil),
 		"total_queue_bindings_up":                             NewSemDesc("rdp_total_queue_bindings_up", NoSempV2Ready, "The total number of queue bindings that are up.", nil),
 		"total_queue_bindings_configured":                     NewSemDesc("rdp_total_queue_bindings_configured", NoSempV2Ready, "The total number of configured queue bindings.", nil),
+	},
+	"MqttSession": {
+		"mqtt_session_info":           NewSemDesc("mqtt_session_info", NoSempV2Ready, "Static information and flags regarding the MQTT session. Value is always 1.", variableLabelsMqttSessionInfo),
+		"mqtt_session_subscriptions":  NewSemDesc("mqtt_session_subscriptions", NoSempV2Ready, "Number of subscriptions for the MQTT session.", variableLabelsMqttSession),
+		"mqtt_session_uptime_seconds": NewSemDesc("mqtt_session_uptime_seconds", NoSempV2Ready, "Uptime of the MQTT session in seconds.", variableLabelsMqttSession),
 	},
 }

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -263,6 +263,12 @@
           <td>yes</td>
           <td>may harm broker if many rest delivery points</td>
         </tr>
+        <tr>
+          <td>MqttSession</td>
+          <td>yes</td>
+          <td>yes</td>
+          <td>may harm broker if many mqtt sessions</td>
+        </tr>
         {{ if .IsHWBroker -}}
         <tr>
           <td>Alarm (only for Hardware brokers)</td>


### PR DESCRIPTION
Hello everyone,

This PR aims to add support for extracting MQTT session details from the broker.

The background is that MQTT clients can exhaust the broker's global capacity without showing up in regular active connection metrics. This occurs when clients connect with the cleanSession (or cleanStart) flag set to false but fail to reuse their Client IDs. As a result, a new durable session object is created upon every connection, while the previously created sessions are kept alive in a disconnected 'waiting' state. Since a single misbehaving client could potentially consume all available client slots on the broker, we need to actively monitor and track the number of MQTT sessions per client username to detect rapid increases early on.


This PR adds the following new metrics:
- `solace_mqtt_session_info` (labels: vpn_name, client_id, owner, clean, durable, enabled)
- `solace_mqtt_session_subscriptions` (labels: vpn_name, client_id, owner)
- `solace_mqtt_session_uptime_seconds` (labels: vpn_name, client_id, owner)

Those should help us create alerts to monitor it ourselves.

Happy to discuss.

Greetings