### PR TITLE
Fix data race on shared Config that leaks credentials between concurrent scrapes

### DIFF
--- a/cmd/solace-prometheus-exporter/concurrency_test.go
+++ b/cmd/solace-prometheus-exporter/concurrency_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"solace_exporter/internal/exporter"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// queueReplyXML is a minimal valid SEMP1 getQueueDetails reply, enough for a scrape to succeed on correct auth.
+const queueReplyXML = `<rpc-reply semp-version="soltr/9_1_1VMR"><rpc><show><queue><queues><queue><name>q1</name>` +
+	`<info><message-vpn>default</message-vpn></info></queue></queues></queue></show></rpc>` +
+	`<execute-result code="ok"/></rpc-reply>`
+
+// mockBroker is a fake Solace SEMP endpoint that records the Basic-auth credentials it receives and rejects any
+// request whose credentials are not its own (as a real broker's LDAP does with a 401).
+type mockBroker struct {
+	server   *httptest.Server
+	user     string
+	pass     string
+	mu       sync.Mutex
+	seen     map[string]int
+	requests int
+}
+
+func newMockBroker(t *testing.T, idx int) *mockBroker {
+	t.Helper()
+	b := &mockBroker{
+		user: fmt.Sprintf("user-%d", idx),
+		pass: fmt.Sprintf("pass-%d", idx),
+		seen: map[string]int{},
+	}
+	b.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+
+		b.mu.Lock()
+		b.seen[u+":"+p]++
+		b.requests++
+		b.mu.Unlock()
+
+		if u != b.user || p != b.pass {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("Unauthorized"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(queueReplyXML))
+	}))
+	t.Cleanup(b.server.Close)
+	return b
+}
+
+// TestConcurrentScrapesDoNotLeakCredentials is the regression test for the credential race: many concurrent /solace
+// scrapes, each carrying its own broker credentials + scrapeURI, must never authenticate to a broker with another broker's
+// credentials. On the buggy code (a single shared *Config mutated per request) this fails both under `-race`
+// (concurrent write/read of conf.Username/Password/ScrapeURI) and functionally (brokers observe foreign creds).
+func TestConcurrentScrapesDoNotLeakCredentials(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	const numBrokers = 8
+	brokers := make([]*mockBroker, numBrokers)
+	for i := range brokers {
+		brokers[i] = newMockBroker(t, i)
+	}
+
+	// Base credentials that are WRONG for every broker: if a request ever fell back to (or was clobbered with) the
+	// shared base Config, the receiving broker would record these and the test would fail.
+	base := &exporter.Config{
+		Username:   "base-should-never-be-used",
+		Password:   "base-should-never-be-used",
+		Timeout:    5 * time.Second,
+		DefaultVpn: "default",
+	}
+
+	dataSource := []exporter.DataSource{{Name: "QueueDetails", VpnFilter: "*", ItemFilter: "*"}}
+
+	const requestsPerBroker = 60
+	var wg sync.WaitGroup
+	for round := 0; round < requestsPerBroker; round++ {
+		for i := range brokers {
+			wg.Add(1)
+			go func(b *mockBroker) {
+				defer wg.Done()
+				form := url.Values{}
+				form.Set("username", b.user)
+				form.Set("password", b.pass)
+				form.Set("scrapeURI", b.server.URL)
+
+				req := httptest.NewRequest(http.MethodPost, "/solace", strings.NewReader(form.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				doHandle(httptest.NewRecorder(), req, dataSource, base, logger)
+			}(brokers[i])
+		}
+	}
+	wg.Wait()
+
+	for i, b := range brokers {
+		b.mu.Lock()
+		if b.requests == 0 {
+			t.Errorf("broker %d (%s) received no requests", i, b.user)
+		}
+		want := b.user + ":" + b.pass
+		for creds, count := range b.seen {
+			if creds != want {
+				t.Errorf("CREDENTIAL LEAK: broker %d (%s) received foreign credentials %q %d time(s)", i, b.user, creds, count)
+			}
+		}
+		b.mu.Unlock()
+	}
+
+	// The shared base Config must be pristine after all concurrent requests.
+	if base.Username != "base-should-never-be-used" || base.Password != "base-should-never-be-used" || base.ScrapeURI != "" {
+		t.Errorf("shared base Config was mutated by request handling: %+v", struct{ U, P, S string }{base.Username, base.Password, base.ScrapeURI})
+	}
+}

--- a/cmd/solace-prometheus-exporter/datasource_test.go
+++ b/cmd/solace-prometheus-exporter/datasource_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"log/slog"
+	"net/url"
+	"os"
+	"sort"
+	"testing"
+)
+
+// TestParseDataSources covers the /solace `m.<Name>=vpn|item[|metricFilter]` parsing used by the SBB nginx proxy.
+func TestParseDataSources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	tests := []struct {
+		name string
+		form url.Values
+		want []string // "Name|Vpn|Item|metricFilterJoinedByComma"
+	}{
+		{
+			name: "single v1 target",
+			form: url.Values{"m.Vpn": {"*|*"}},
+			want: []string{"Vpn|*|*|"},
+		},
+		{
+			name: "v2 target with metric filter",
+			form: url.Values{"m.QueueStats": {"myvpn|myqueue|rx,tx"}},
+			want: []string{"QueueStats|myvpn|myqueue|rx,tx"},
+		},
+		{
+			name: "multiple targets and non-m keys ignored",
+			form: url.Values{
+				"m.Health":    {"*|*"},
+				"m.Spool":     {"*|*"},
+				"username":    {"ignored"},
+				"scrapeURI":   {"http://ignored"},
+				"m.QueueRate": {"vpn|item"},
+			},
+			want: []string{"Health|*|*|", "QueueRate|vpn|item|", "Spool|*|*|"},
+		},
+		{
+			name: "malformed value (no pipe) is skipped",
+			form: url.Values{"m.Vpn": {"noPipeHere"}},
+			want: nil,
+		},
+		{
+			name: "empty metric filter part is treated as absent",
+			form: url.Values{"m.QueueStats": {"vpn|item|  "}},
+			want: []string{"QueueStats|vpn|item|"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDataSources(tt.form, logger)
+			var gotStr []string
+			for _, ds := range got {
+				mf := ""
+				for i, m := range ds.MetricFilter {
+					if i > 0 {
+						mf += ","
+					}
+					mf += m
+				}
+				gotStr = append(gotStr, ds.Name+"|"+ds.VpnFilter+"|"+ds.ItemFilter+"|"+mf)
+			}
+			sort.Strings(gotStr)
+			sort.Strings(tt.want)
+
+			if len(gotStr) != len(tt.want) {
+				t.Fatalf("got %v, want %v", gotStr, tt.want)
+			}
+			for i := range gotStr {
+				if gotStr[i] != tt.want[i] {
+					t.Errorf("got[%d]=%q want %q (all got=%v)", i, gotStr[i], tt.want[i], gotStr)
+				}
+			}
+		})
+	}
+}

--- a/cmd/solace-prometheus-exporter/handler_test.go
+++ b/cmd/solace-prometheus-exporter/handler_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"regexp"
+	"solace_exporter/internal/exporter"
+	"strings"
+	"testing"
+	"time"
+)
+
+var solaceUpRe = regexp.MustCompile(`(?m)^solace_up\{[^}]*\}\s+([0-9.]+)`)
+
+func scrapeUp(t *testing.T, body string) string {
+	t.Helper()
+	m := solaceUpRe.FindStringSubmatch(body)
+	if m == nil {
+		t.Fatalf("no solace_up metric found in response body:\n%s", body)
+	}
+	return m[1]
+}
+
+// TestDoHandleEndToEnd exercises the full /solace scrape path (request -> per-request config -> exporter -> SEMP)
+// and asserts solace_up reflects authentication success/failure with the per-request credentials.
+func TestDoHandleEndToEnd(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	broker := newMockBroker(t, 42) // expects user-42 / pass-42
+	base := &exporter.Config{Username: "wrong-base", Password: "wrong-base", Timeout: 5 * time.Second, DefaultVpn: "default"}
+	ds := []exporter.DataSource{{Name: "QueueDetails", VpnFilter: "*", ItemFilter: "*"}}
+
+	do := func(user, pass string) string {
+		form := url.Values{}
+		form.Set("username", user)
+		form.Set("password", pass)
+		form.Set("scrapeURI", broker.server.URL)
+		req := httptest.NewRequest(http.MethodPost, "/solace", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+		doHandle(rr, req, ds, base, logger)
+		return rr.Body.String()
+	}
+
+	t.Run("correct credentials -> up 1", func(t *testing.T) {
+		if up := scrapeUp(t, do("user-42", "pass-42")); up != "1" {
+			t.Errorf("solace_up = %s, want 1 (broker should accept correct credentials)", up)
+		}
+	})
+
+	t.Run("wrong credentials -> up 0", func(t *testing.T) {
+		if up := scrapeUp(t, do("user-42", "bad-pass")); up != "0" {
+			t.Errorf("solace_up = %s, want 0 (broker should 401 wrong credentials)", up)
+		}
+	})
+}
+
+// TestDoHandleExporterAuthProtectsEndpoint verifies the exporter endpoint itself can be protected with basic auth
+// (SOLACE_EXPORTER_AUTH_*), independent of the broker credentials.
+func TestDoHandleExporterAuthProtectsEndpoint(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	broker := newMockBroker(t, 7)
+
+	base := &exporter.Config{
+		Username:     "user-7",
+		Password:     "pass-7",
+		ScrapeURI:    broker.server.URL,
+		Timeout:      5 * time.Second,
+		DefaultVpn:   "default",
+		ExporterAuth: exporter.ExporterAuthConfig{Scheme: "basic", Username: "scrape-user", Password: "scrape-pass"},
+	}
+	ds := []exporter.DataSource{{Name: "QueueDetails", VpnFilter: "*", ItemFilter: "*"}}
+
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/solace", nil)
+		return req
+	}
+
+	// Without exporter credentials -> 401.
+	rr := httptest.NewRecorder()
+	doHandle(rr, newReq(), ds, base, logger)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("without exporter auth: status = %d, want 401", rr.Code)
+	}
+
+	// With correct exporter credentials -> allowed (200) and a scrape happens.
+	rr = httptest.NewRecorder()
+	req := newReq()
+	req.SetBasicAuth("scrape-user", "scrape-pass")
+	doHandle(rr, req, ds, base, logger)
+	if rr.Code != http.StatusOK {
+		t.Errorf("with exporter auth: status = %d, want 200", rr.Code)
+	}
+}

--- a/cmd/solace-prometheus-exporter/main.go
+++ b/cmd/solace-prometheus-exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"solace_exporter/internal/exporter"
 	"solace_exporter/internal/web"
@@ -75,7 +76,7 @@ func main() {
 		if conf.PrefetchInterval.Seconds() > 0 {
 			var asyncFetcher = exporter.NewAsyncFetcher(context.Background(), urlPath, dataSource, conf, logger, sempConnections)
 			http.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
-				doHandleAsync(w, r, asyncFetcher)
+				doHandleAsync(w, r, asyncFetcher, conf)
 			})
 		} else {
 			http.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
@@ -88,37 +89,12 @@ func main() {
 	}
 
 	http.HandleFunc("/solace", func(w http.ResponseWriter, r *http.Request) {
-		var err = r.ParseForm()
-		if err != nil {
+		if err := r.ParseForm(); err != nil {
 			logger.Error("Can not parse the request parameter", "err", err)
 			return
 		}
 
-		var dataSource []exporter.DataSource
-		for key, values := range r.Form {
-			if strings.HasPrefix(key, "m.") {
-				for _, value := range values {
-					parts := strings.Split(value, "|")
-					if len(parts) < 2 {
-						logger.Error("One or two | expected. Use VPN wildcard | Item wildcard | Optional metric filter for v2 apis", "key", key, "value", value)
-					} else {
-						var metricFilter []string
-						if len(parts) == 3 && len(strings.TrimSpace(parts[2])) > 0 {
-							metricFilter = strings.Split(parts[2], ",")
-						}
-
-						dataSource = append(dataSource, exporter.DataSource{
-							Name:         strings.TrimPrefix(key, "m."),
-							VpnFilter:    parts[0],
-							ItemFilter:   parts[1],
-							MetricFilter: metricFilter,
-						})
-					}
-				}
-			}
-		}
-
-		doHandle(w, r, dataSource, conf, logger)
+		doHandle(w, r, parseDataSources(r.Form, logger), conf, logger)
 	})
 
 	endpointViews := make([]web.EndpointView, 0, len(endpoints))
@@ -156,10 +132,12 @@ func main() {
 	}
 }
 
-func doHandleAsync(w http.ResponseWriter, r *http.Request, asyncFetcher *exporter.AsyncFetcher) string {
+func doHandleAsync(w http.ResponseWriter, r *http.Request, asyncFetcher *exporter.AsyncFetcher, conf *exporter.Config) string {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(asyncFetcher)
-	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	// Protect prefetch endpoints with the same exporter auth as the synchronous handlers (they previously served
+	// metrics unauthenticated even when SOLACE_EXPORTER_AUTH_* was configured).
+	handler := web.WrapWithAuth(promhttp.HandlerFor(registry, promhttp.HandlerOpts{}), conf.ExporterAuth)
 	handler.ServeHTTP(w, r)
 
 	return w.Header().Get("status")
@@ -170,43 +148,14 @@ func doHandle(w http.ResponseWriter, r *http.Request, dataSource []exporter.Data
 	if dataSource == nil {
 		handler = promhttp.Handler()
 	} else {
-		// Exporter for endpoint
-		username := r.FormValue("username")
-		if len(username) == 0 {
-			username = r.Header.Get("x-solace-broker-username")
-		}
-		password := r.FormValue("password")
-		if len(password) == 0 {
-			password = r.Header.Get("x-solace-broker-password")
-		}
-		scrapeURI := r.FormValue("scrapeURI")
-		if len(scrapeURI) == 0 {
-			scrapeURI = r.Header.Get("x-solace-broker-scrapeuri")
-		}
-		timeout := r.FormValue("timeout")
-		if len(timeout) == 0 {
-			timeout = r.Header.Get("x-solace-broker-timeout")
-		}
-		if len(username) > 0 {
-			conf.Username = username
-		}
-		if len(password) > 0 {
-			conf.Password = password
-		}
-		if len(scrapeURI) > 0 {
-			conf.ScrapeURI = scrapeURI
-		}
-		if len(timeout) > 0 {
-			var err error
-			conf.Timeout, err = time.ParseDuration(timeout)
-			if err != nil {
-				logger.Error("Per HTTP given timeout parameter is not valid", "err", err, "timeout", timeout)
-			}
-		}
+		// Each request scrapes a broker whose credentials / scrapeURI come from the request itself. We therefore
+		// work on a per-request Config copy so that concurrent scrapes can NOT overwrite each other's credentials
+		// on a shared Config (which caused broker-wide SEMP 401s).
+		reqConf := resolveRequestConfig(r, conf, logger)
 
-		logger.Info("handle http request", "dataSource", logDataSource(dataSource), "scrapeURI", conf.ScrapeURI)
+		logger.Info("handle http request", "dataSource", logDataSource(dataSource), "scrapeURI", reqConf.ScrapeURI)
 
-		exp := exporter.NewExporter(r.Context(), logger, conf, &dataSource)
+		exp := exporter.NewExporter(r.Context(), logger, reqConf, &dataSource)
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(exp)
 		handler = promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
@@ -215,4 +164,79 @@ func doHandle(w http.ResponseWriter, r *http.Request, dataSource []exporter.Data
 
 	securedHandler.ServeHTTP(w, r)
 	return w.Header().Get("status")
+}
+
+// parseDataSources builds the list of scrape targets from the request form. Each `m.<Name>` parameter holds
+// `vpnFilter|itemFilter[|metricFilter,...]`; entries with fewer than two `|`-separated parts are skipped with a log.
+func parseDataSources(form url.Values, logger *slog.Logger) []exporter.DataSource {
+	var dataSource []exporter.DataSource
+	for key, values := range form {
+		if !strings.HasPrefix(key, "m.") {
+			continue
+		}
+		for _, value := range values {
+			parts := strings.Split(value, "|")
+			if len(parts) < 2 {
+				logger.Error("One or two | expected. Use VPN wildcard | Item wildcard | Optional metric filter for v2 apis", "key", key, "value", value)
+				continue
+			}
+
+			var metricFilter []string
+			if len(parts) == 3 && len(strings.TrimSpace(parts[2])) > 0 {
+				metricFilter = strings.Split(parts[2], ",")
+			}
+
+			dataSource = append(dataSource, exporter.DataSource{
+				Name:         strings.TrimPrefix(key, "m."),
+				VpnFilter:    parts[0],
+				ItemFilter:   parts[1],
+				MetricFilter: metricFilter,
+			})
+		}
+	}
+	return dataSource
+}
+
+// resolveRequestConfig returns a per-request copy of conf with the credentials, scrape URI and timeout overridden
+// from the request. For each value the form parameter wins, then the x-solace-broker-* header, otherwise the value
+// configured on the base Config is kept. The shared base conf is never mutated, so concurrent requests are fully
+// isolated from one another.
+func resolveRequestConfig(r *http.Request, conf *exporter.Config, logger *slog.Logger) *exporter.Config {
+	reqConf := conf.Clone()
+
+	if username := firstNonEmpty(r.FormValue("username"), r.Header.Get("x-solace-broker-username")); username != "" {
+		reqConf.Username = username
+	}
+	if password := firstNonEmpty(r.FormValue("password"), r.Header.Get("x-solace-broker-password")); password != "" {
+		reqConf.Password = password
+	}
+	if scrapeURI := firstNonEmpty(r.FormValue("scrapeURI"), r.Header.Get("x-solace-broker-scrapeuri")); scrapeURI != "" {
+		reqConf.ScrapeURI = scrapeURI
+	}
+	if timeout := firstNonEmpty(r.FormValue("timeout"), r.Header.Get("x-solace-broker-timeout")); timeout != "" {
+		parsed, err := time.ParseDuration(timeout)
+		switch {
+		case err != nil:
+			// Keep the configured timeout instead of silently disabling it (an invalid value used to zero it).
+			logger.Error("Per HTTP given timeout parameter is not valid", "err", err, "timeout", timeout)
+		case parsed <= 0:
+			// A non-positive timeout means "no timeout" for http.Client; a hung broker could then pin a scrape
+			// (and a SEMP connection slot) forever. Keep the configured timeout instead.
+			logger.Error("Per HTTP given timeout must be positive; keeping configured timeout", "timeout", timeout)
+		default:
+			reqConf.Timeout = parsed
+		}
+	}
+
+	return reqConf
+}
+
+// firstNonEmpty returns the first non-empty string of the given values, or "" if all are empty.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if len(v) > 0 {
+			return v
+		}
+	}
+	return ""
 }

--- a/cmd/solace-prometheus-exporter/main_test.go
+++ b/cmd/solace-prometheus-exporter/main_test.go
@@ -10,15 +10,17 @@ import (
 	"time"
 )
 
-func TestDoHandleHeaderOverride(t *testing.T) {
+// TestResolveRequestConfig verifies that per-request credentials/scrapeURI/timeout are resolved with the correct
+// precedence (form value > x-solace-broker-* header > configured base value) AND that the shared base Config is
+// never mutated - which is the fix for the broker-wide SEMP 401 storm.
+func TestResolveRequestConfig(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	dataSource := []exporter.DataSource{{Name: "test"}}
 
 	tests := []struct {
 		name              string
 		queryParams       map[string]string
 		headers           map[string]string
-		initialConf       *exporter.Config
+		base              exporter.Config
 		expectedUsername  string
 		expectedPassword  string
 		expectedScrapeURI string
@@ -32,7 +34,7 @@ func TestDoHandleHeaderOverride(t *testing.T) {
 				"x-solace-broker-scrapeuri": "http://header-uri",
 				"x-solace-broker-timeout":   "10s",
 			},
-			initialConf:       &exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			base:              exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
 			expectedUsername:  "header-user",
 			expectedPassword:  "header-pass",
 			expectedScrapeURI: "http://header-uri",
@@ -52,7 +54,7 @@ func TestDoHandleHeaderOverride(t *testing.T) {
 				"x-solace-broker-scrapeuri": "http://header-uri",
 				"x-solace-broker-timeout":   "10s",
 			},
-			initialConf:       &exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			base:              exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
 			expectedUsername:  "form-user",
 			expectedPassword:  "form-pass",
 			expectedScrapeURI: "http://form-uri",
@@ -61,11 +63,20 @@ func TestDoHandleHeaderOverride(t *testing.T) {
 		{
 			name:              "Fallback to config",
 			headers:           map[string]string{},
-			initialConf:       &exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			base:              exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
 			expectedUsername:  "conf-user",
 			expectedPassword:  "conf-pass",
 			expectedScrapeURI: "http://conf-uri",
 			expectedTimeout:   5 * time.Second,
+		},
+		{
+			name:              "Invalid timeout keeps configured timeout",
+			queryParams:       map[string]string{"timeout": "not-a-duration"},
+			base:              exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 7 * time.Second},
+			expectedUsername:  "conf-user",
+			expectedPassword:  "conf-pass",
+			expectedScrapeURI: "http://conf-uri",
+			expectedTimeout:   7 * time.Second,
 		},
 	}
 
@@ -83,31 +94,55 @@ func TestDoHandleHeaderOverride(t *testing.T) {
 			for k, v := range tt.headers {
 				req.Header.Set(k, v)
 			}
-			rr := httptest.NewRecorder()
 
-			// Create a new config to avoid copying the mutex
-			conf := exporter.Config{
-				Username:  tt.initialConf.Username,
-				Password:  tt.initialConf.Password,
-				ScrapeURI: tt.initialConf.ScrapeURI,
-				Timeout:   tt.initialConf.Timeout,
-				// copy other fields if necessary for doHandle
-				ExporterAuth: tt.initialConf.ExporterAuth,
-			}
-			// We need to pass a pointer to conf because doHandle modifies it.
-			doHandle(rr, req, dataSource, &conf, logger)
+			base := tt.base // keep a copy of the original to detect mutation
+			reqConf := resolveRequestConfig(req, &base, logger)
 
-			if conf.Username != tt.expectedUsername {
-				t.Errorf("Username: expected %s, got %s", tt.expectedUsername, conf.Username)
+			if reqConf.Username != tt.expectedUsername {
+				t.Errorf("Username: expected %s, got %s", tt.expectedUsername, reqConf.Username)
 			}
-			if conf.Password != tt.expectedPassword {
-				t.Errorf("Password: expected %s, got %s", tt.expectedPassword, conf.Password)
+			if reqConf.Password != tt.expectedPassword {
+				t.Errorf("Password: expected %s, got %s", tt.expectedPassword, reqConf.Password)
 			}
-			if conf.ScrapeURI != tt.expectedScrapeURI {
-				t.Errorf("ScrapeURI: expected %s, got %s", tt.expectedScrapeURI, conf.ScrapeURI)
+			if reqConf.ScrapeURI != tt.expectedScrapeURI {
+				t.Errorf("ScrapeURI: expected %s, got %s", tt.expectedScrapeURI, reqConf.ScrapeURI)
 			}
-			if conf.Timeout != tt.expectedTimeout {
-				t.Errorf("Timeout: expected %v, got %v", tt.expectedTimeout, conf.Timeout)
+			if reqConf.Timeout != tt.expectedTimeout {
+				t.Errorf("Timeout: expected %v, got %v", tt.expectedTimeout, reqConf.Timeout)
+			}
+
+			// The shared base Config must NOT be mutated by request resolution.
+			if base.Username != tt.base.Username || base.Password != tt.base.Password ||
+				base.ScrapeURI != tt.base.ScrapeURI || base.Timeout != tt.base.Timeout {
+				t.Errorf("base Config was mutated: got %+v, want %+v",
+					struct {
+						U, P, S string
+						T       time.Duration
+					}{base.Username, base.Password, base.ScrapeURI, base.Timeout},
+					struct {
+						U, P, S string
+						T       time.Duration
+					}{tt.base.Username, tt.base.Password, tt.base.ScrapeURI, tt.base.Timeout})
+			}
+		})
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{"all empty", []string{"", ""}, ""},
+		{"first wins", []string{"a", "b"}, "a"},
+		{"skip empty", []string{"", "b", "c"}, "b"},
+		{"none", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstNonEmpty(tt.values...); got != tt.want {
+				t.Errorf("firstNonEmpty(%v) = %q, want %q", tt.values, got, tt.want)
 			}
 		})
 	}

--- a/internal/exporter/asyncFetcher.go
+++ b/internal/exporter/asyncFetcher.go
@@ -80,6 +80,12 @@ func readMetrics(f *AsyncFetcher) {
 
 	go func() {
 		defer close(metricsChan)
+		// A malformed/unexpected broker reply must not crash the exporter process; recover and log instead.
+		defer func() {
+			if r := recover(); r != nil {
+				f.logger.Error("recovered from panic while scraping broker (async)", "panic", r)
+			}
+		}()
 		f.exporter.CollectPrometheusMetric(metricsChan)
 	}()
 

--- a/internal/exporter/asyncFetcher_test.go
+++ b/internal/exporter/asyncFetcher_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"solace_exporter/internal/semp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -74,12 +75,12 @@ func TestNewAsyncFetcher(t *testing.T) {
 	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	// state variable
-	state := 0
+	// state variable (read by the mock server goroutine, written by the test goroutine)
+	var state atomic.Int32
 
 	// setup a mock webserver
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch state {
+		switch state.Load() {
 		case 0:
 			// That return an ok response for: getQueueDetailsSemp1
 			w.WriteHeader(http.StatusOK)
@@ -147,14 +148,14 @@ func TestNewAsyncFetcher(t *testing.T) {
 
 	checkUp(1.0)
 
-	state = 1
+	state.Store(1)
 	time.Sleep(2500 * time.Millisecond) // Wait for the 2sec timeout and fetch
-	state = 2
+	state.Store(2)
 	time.Sleep(500 * time.Millisecond)
 	// expect solace_up to be 0
 	checkUp(0.0)
 
-	state = 3
+	state.Store(3)
 	time.Sleep(1000 * time.Millisecond)
 	// expect solace_up to be 1
 	checkUp(1.0)

--- a/internal/exporter/auth.go
+++ b/internal/exporter/auth.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"time"
 
@@ -17,44 +18,58 @@ const (
 	AuthTypeOAuth
 )
 
-// setAuthHeader sets the appropriate authentication header on the request based on the configured auth type.
-// It returns a function that can be used to set the header on an http.Request, or an error if there was an issue obtaining an OAuth token.
+// setAuthHeader returns a visitor that applies the configured authentication to an *http.Request.
+// The returned visitor is always non-nil. For OAuth, token retrieval is deferred to request time (see below), so
+// this function does not fetch a token and currently never returns a non-nil error; the error is retained in the
+// signature for callers to remain correct should auth setup gain a failure mode.
 func (conf *Config) setAuthHeader(ctx context.Context) (func(*http.Request), error) {
-	if conf.authType == AuthTypeBasic {
+	switch conf.authType {
+	case AuthTypeBasic:
 		return func(request *http.Request) {
 			request.SetBasicAuth(conf.Username, conf.Password)
 		}, nil
-	}
-	if conf.authType == AuthTypeOAuth {
-		token, err := conf.getOAuthToken(ctx)
-		if err != nil {
-			return nil, err
-		}
+	case AuthTypeOAuth:
+		// Fetch the token from the shared cache on EVERY request (it refreshes shortly before expiry). Capturing
+		// the token string once here would make long-lived async prefetch fetchers keep sending a stale bearer
+		// after it expires, causing broker-wide 401s.
 		return func(request *http.Request) {
+			token, err := conf.getOAuthToken(ctx)
+			if err != nil {
+				// Leave Authorization unset so the scrape fails visibly (solace_up=0) rather than sending a
+				// stale/blank token. We never return a nil visitor, which would panic the scrape.
+				return
+			}
 			request.Header.Set("Authorization", "Bearer "+conf.issuerPrefixedToken(token))
 		}, nil
+	default:
+		// No auth configured.
+		return func(*http.Request) {}, nil
 	}
-
-	// Optionally default to no auth
-	return func(request *http.Request) {}, nil
 }
 
 // getOAuthToken retrieves a new OAuth token using the client credentials flow if the current token is expired or about to expire.
+// The token is cached in the shared oAuthToken cache, so that concurrent scrape requests (each on its own Config.Clone)
+// reuse the same token instead of each fetching a new one.
 func (conf *Config) getOAuthToken(ctx context.Context) (string, error) {
-	conf.oAuthTokenMutex.RLock()
-	if conf.oAuthAccessToken != "" && time.Now().Before(conf.oAuthTokenExpiry.Add(-time.Minute*5)) {
-		token := conf.oAuthAccessToken
-		conf.oAuthTokenMutex.RUnlock()
+	cache := conf.oAuthToken
+	if cache == nil {
+		return "", errors.New("oauth token cache is not initialised; build the Config via ParseConfig")
+	}
+
+	cache.mu.RLock()
+	if cache.token != "" && time.Now().Before(cache.expiry.Add(-time.Minute*5)) {
+		token := cache.token
+		cache.mu.RUnlock()
 		return token, nil
 	}
-	conf.oAuthTokenMutex.RUnlock()
+	cache.mu.RUnlock()
 
-	conf.oAuthTokenMutex.Lock()
-	defer conf.oAuthTokenMutex.Unlock()
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 
 	// Double-check after acquiring the write lock
-	if conf.oAuthAccessToken != "" && time.Now().Before(conf.oAuthTokenExpiry.Add(-time.Minute*5)) {
-		return conf.oAuthAccessToken, nil
+	if cache.token != "" && time.Now().Before(cache.expiry.Add(-time.Minute*5)) {
+		return cache.token, nil
 	}
 
 	client := conf.basicHTTPClient()
@@ -72,17 +87,19 @@ func (conf *Config) getOAuthToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	conf.oAuthAccessToken = token.AccessToken
-	conf.oAuthTokenExpiry = token.Expiry
+	cache.token = token.AccessToken
+	cache.expiry = token.Expiry
 
-	return conf.oAuthAccessToken, nil
+	return cache.token, nil
 }
 
 func (conf *Config) issuerPrefixedToken(token string) string {
 	if conf.OAuthIssuer == "" {
 		return token
 	}
-	encoded := base64.StdEncoding.EncodeToString([]byte(conf.OAuthIssuer))
-	trimmed := encoded[:len(encoded)-1]
-	return "~" + trimmed + "~" + token
+	// Solace expects the issuer as unpadded base64 between '~' markers. Using RawStdEncoding avoids the previous
+	// fragile "strip exactly one '=' " logic, which corrupted the value for issuer lengths whose base64 had zero
+	// or two padding characters.
+	encoded := base64.RawStdEncoding.EncodeToString([]byte(conf.OAuthIssuer))
+	return "~" + encoded + "~" + token
 }

--- a/internal/exporter/auth_test.go
+++ b/internal/exporter/auth_test.go
@@ -1,0 +1,197 @@
+package exporter
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newOAuthTokenServer(t *testing.T, hits *atomic.Int32, accessToken string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + accessToken + `","token_type":"bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func newOAuthConfig(tokenURL string) *Config {
+	return &Config{
+		OAuthTokenURL:     tokenURL,
+		OAuthClientID:     "client",
+		OAuthClientSecret: "secret",
+		OAuthClientScope:  "scope",
+		authType:          AuthTypeOAuth,
+		Timeout:           5 * time.Second,
+		oAuthToken:        &oAuthTokenCache{},
+	}
+}
+
+// TestGetOAuthTokenIsCachedAcrossConcurrentRequests verifies the OAuth token is fetched exactly once and reused by
+// all concurrent callers (the reason commit 00600f0 shared the Config by pointer) - now achieved safely via the
+// shared oAuthTokenCache without racing the credential fields.
+func TestGetOAuthTokenIsCachedAcrossConcurrentRequests(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	ts := newOAuthTokenServer(t, &hits, "tok-123")
+	conf := newOAuthConfig(ts.URL)
+
+	const n = 50
+	var wg sync.WaitGroup
+	tokens := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tokens[i], errs[i] = conf.getOAuthToken(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("getOAuthToken returned error: %v", errs[i])
+		}
+		if tokens[i] != "tok-123" {
+			t.Errorf("token[%d] = %q, want tok-123", i, tokens[i])
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected exactly 1 token fetch (cached), got %d", got)
+	}
+}
+
+// TestOAuthTokenCacheIsSharedAcrossClones is the OAuth counterpart of the credential-isolation fix: a per-request
+// Config.Clone() must still share the token cache, so cloning for isolation does NOT reintroduce repeated token
+// fetches.
+func TestOAuthTokenCacheIsSharedAcrossClones(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	ts := newOAuthTokenServer(t, &hits, "tok-abc")
+	base := newOAuthConfig(ts.URL)
+
+	const n = 30
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clone := base.Clone() // each "request" gets its own clone...
+			tok, err := clone.getOAuthToken(context.Background())
+			if err != nil {
+				t.Errorf("getOAuthToken error: %v", err)
+			}
+			if tok != "tok-abc" {
+				t.Errorf("token = %q, want tok-abc", tok)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected exactly 1 token fetch shared across clones, got %d", got)
+	}
+}
+
+// TestGetOAuthTokenNilCacheReturnsError ensures a Config without an initialised cache fails loudly instead of panicking.
+func TestGetOAuthTokenNilCacheReturnsError(t *testing.T) {
+	t.Parallel()
+	conf := &Config{authType: AuthTypeOAuth} // no oAuthToken
+	if _, err := conf.getOAuthToken(context.Background()); err == nil {
+		t.Fatal("expected an error for a nil OAuth token cache, got nil")
+	}
+}
+
+// TestCloneIsolatesCredentials verifies Clone gives an independent copy of the per-request scrape fields while
+// sharing the OAuth token cache pointer.
+func TestCloneIsolatesCredentials(t *testing.T) {
+	t.Parallel()
+	base := &Config{Username: "u", Password: "p", ScrapeURI: "http://base", oAuthToken: &oAuthTokenCache{}}
+	clone := base.Clone()
+	clone.Username = "other"
+	clone.Password = "other"
+	clone.ScrapeURI = "http://other"
+
+	if base.Username != "u" || base.Password != "p" || base.ScrapeURI != "http://base" {
+		t.Errorf("mutating clone changed base: %+v", struct{ U, P, S string }{base.Username, base.Password, base.ScrapeURI})
+	}
+	if clone.oAuthToken != base.oAuthToken {
+		t.Error("clone must share the OAuth token cache pointer with the base config")
+	}
+}
+
+// TestIssuerPrefixedToken checks the Solace issuer-prefixed token format uses UNPADDED base64 for issuers of every
+// length class (the old code stripped exactly one char, corrupting issuers whose base64 had 0 or 2 padding chars).
+func TestIssuerPrefixedToken(t *testing.T) {
+	t.Parallel()
+
+	// no issuer -> token unchanged
+	no := &Config{}
+	if got := no.issuerPrefixedToken("tok"); got != "tok" {
+		t.Errorf("no issuer: got %q, want tok", got)
+	}
+
+	// issuers of len%3 == 0,1,2 exercise base64 padding of 0,2,1 chars respectively
+	for _, issuer := range []string{"abc", "ab", "a", "abcd", "https://idp.example.com/realm"} {
+		c := &Config{OAuthIssuer: issuer}
+		got := c.issuerPrefixedToken("TOKEN")
+		want := "~" + base64.RawStdEncoding.EncodeToString([]byte(issuer)) + "~TOKEN"
+		if got != want {
+			t.Errorf("issuer %q: got %q, want %q", issuer, got, want)
+		}
+		if strings.Contains(got, "=") {
+			t.Errorf("issuer %q: prefixed token must not contain base64 padding: %q", issuer, got)
+		}
+	}
+}
+
+// TestSetAuthHeaderOAuthReFetchesToken verifies the OAuth visitor fetches the token from the cache on EVERY request
+// (so a long-lived visitor picks up a refreshed token) rather than capturing one token string forever.
+func TestSetAuthHeaderOAuthReFetchesToken(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	ts := newOAuthTokenServer(t, &hits, "tok-xyz")
+	conf := newOAuthConfig(ts.URL)
+
+	visit, err := conf.setAuthHeader(context.Background())
+	if err != nil {
+		t.Fatalf("setAuthHeader error: %v", err)
+	}
+	// Invoke the visitor several times: it must set a Bearer header each time (fetching/reusing the cached token),
+	// never leaving a nil visitor or a stale/empty header.
+	for i := 0; i < 3; i++ {
+		req, _ := http.NewRequest(http.MethodPost, "http://broker/SEMP", nil)
+		visit(req)
+		if got := req.Header.Get("Authorization"); got != "Bearer tok-xyz" {
+			t.Errorf("Authorization = %q, want Bearer tok-xyz", got)
+		}
+	}
+	if hits.Load() != 1 {
+		t.Errorf("token should be cached: expected 1 fetch, got %d", hits.Load())
+	}
+}
+
+// TestSetAuthHeaderBasic verifies the basic-auth visitor sets the request's credentials from the (per-request) Config.
+func TestSetAuthHeaderBasic(t *testing.T) {
+	t.Parallel()
+	conf := &Config{authType: AuthTypeBasic, Username: "user-x", Password: "pass-x"}
+	visit, err := conf.setAuthHeader(context.Background())
+	if err != nil {
+		t.Fatalf("setAuthHeader error: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPost, "http://broker/SEMP", nil)
+	visit(req)
+	u, p, ok := req.BasicAuth()
+	if !ok || u != "user-x" || p != "pass-x" {
+		t.Errorf("basic auth = (%q,%q,%v), want (user-x,pass-x,true)", u, p, ok)
+	}
+}

--- a/internal/exporter/config.struct.go
+++ b/internal/exporter/config.struct.go
@@ -20,7 +20,21 @@ type ExporterAuthConfig struct {
 	Password string `json:"-"`
 }
 
-// Config Collection of configs
+// oAuthTokenCache holds the shared, mutable OAuth client-credentials token so it can be reused across scrape
+// requests instead of being fetched for every request. It is referenced by pointer from Config so that a per-request
+// Config copy (see Config.Clone) shares the SAME cache (keeping the token warm) without copying the mutex.
+type oAuthTokenCache struct {
+	mu     sync.RWMutex
+	token  string
+	expiry time.Time
+}
+
+// Config Collection of configs.
+//
+// The per-request scrape fields (ScrapeURI, Username, Password, Timeout) are mutated per HTTP request in the
+// dynamic (/solace) handler. To keep concurrent scrapes from clobbering each other's credentials, every request
+// works on its own Config.Clone(); the shared base Config is never mutated after startup. The only intentionally
+// shared mutable state is oAuthToken (a pointer), so the OAuth token cache stays warm across requests.
 type Config struct {
 	ListenAddr              string
 	EnableTLS               bool
@@ -45,11 +59,18 @@ type Config struct {
 	OAuthClientSecret       string
 	OAuthClientScope        string
 	OAuthIssuer             string
-	oAuthAccessToken        string
-	oAuthTokenExpiry        time.Time
-	oAuthTokenMutex         sync.RWMutex
+	oAuthToken              *oAuthTokenCache
 	authType                AuthType
 	ExporterAuth            ExporterAuthConfig
+}
+
+// Clone returns a shallow copy of the Config that is safe to mutate per request. Scalar fields (ScrapeURI,
+// Username, Password, Timeout, ...) are copied by value so that overriding them on the clone does NOT affect the
+// shared base Config or any other in-flight request. The oAuthToken cache is shared by pointer on purpose, so the
+// OAuth token obtained by one request is reused by the others.
+func (conf *Config) Clone() *Config {
+	c := *conf
+	return &c
 }
 
 const (
@@ -71,7 +92,7 @@ func ParseConfig(configFile string) (map[string][]DataSource, *Config, error) {
 	var cfg *ini.File
 	var err error
 
-	conf := &Config{}
+	conf := &Config{oAuthToken: &oAuthTokenCache{}}
 
 	if len(configFile) > 0 {
 		opts := ini.LoadOptions{
@@ -155,16 +176,22 @@ func ParseConfig(configFile string) (map[string][]DataSource, *Config, error) {
 	conf.Username = parseConfigStringOptional(cfg, "solace", "username", "SOLACE_USERNAME", "admin")
 	conf.Password = parseConfigStringOptional(cfg, "solace", "password", "SOLACE_PASSWORD", "admin")
 
-	if (len(conf.Username) == 0 || len(conf.Password) == 0) && (len(conf.OAuthClientID) == 0 || len(conf.OAuthClientSecret) == 0 || len(conf.OAuthTokenURL) == 0 || len(conf.OAuthClientScope) == 0) {
-		return nil, nil, errors.New("either basic auth (username+password) or OAuth (oAuthClientID+oAuthClientSecret+oAuthTokenURL+oAuthClientScope) must be configured")
+	anyOAuth := len(conf.OAuthClientID) > 0 || len(conf.OAuthClientSecret) > 0 || len(conf.OAuthTokenURL) > 0 || len(conf.OAuthClientScope) > 0
+	allOAuth := len(conf.OAuthClientID) > 0 && len(conf.OAuthClientSecret) > 0 && len(conf.OAuthTokenURL) > 0 && len(conf.OAuthClientScope) > 0
+
+	// If any OAuth field is set the user intends OAuth, so require all of them instead of silently falling back to
+	// the default admin/admin basic credentials (which would then 401 in a confusing way).
+	if anyOAuth && !allOAuth {
+		return nil, nil, errors.New("incomplete OAuth configuration: oAuthClientID, oAuthClientSecret, oAuthTokenURL and oAuthClientScope must all be set")
 	}
 
-	if len(conf.Username) > 0 && len(conf.Password) > 0 {
-		conf.authType = AuthTypeBasic
-	}
-
-	if len(conf.OAuthClientID) > 0 && len(conf.OAuthClientSecret) > 0 && len(conf.OAuthTokenURL) > 0 && len(conf.OAuthClientScope) > 0 {
+	switch {
+	case allOAuth:
 		conf.authType = AuthTypeOAuth
+	case len(conf.Username) > 0 && len(conf.Password) > 0:
+		conf.authType = AuthTypeBasic
+	default:
+		return nil, nil, errors.New("either basic auth (username+password) or OAuth (oAuthClientID+oAuthClientSecret+oAuthTokenURL+oAuthClientScope) must be configured")
 	}
 
 	if conf.ParallelSempConnections < 1 {

--- a/internal/exporter/config_parse_test.go
+++ b/internal/exporter/config_parse_test.go
@@ -1,0 +1,138 @@
+package exporter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// clearSolaceEnv removes all SOLACE_* / PREFETCH_INTERVAL env vars so a test starts from a known state, restoring
+// them via t.Cleanup so tests stay independent of the ambient environment. It uses os.LookupEnv so a variable that
+// was unset is restored to unset (not to an empty string), avoiding state leaking across tests.
+func clearSolaceEnv(t *testing.T) {
+	t.Helper()
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(key, "SOLACE_") || key == "PREFETCH_INTERVAL" {
+			k := key
+			old, had := os.LookupEnv(k)
+			_ = os.Unsetenv(k)
+			t.Cleanup(func() {
+				if had {
+					_ = os.Setenv(k, old)
+				} else {
+					_ = os.Unsetenv(k)
+				}
+			})
+		}
+	}
+}
+
+func TestParseConfigBasicAuthFromEnv(t *testing.T) {
+	clearSolaceEnv(t)
+	t.Setenv("SOLACE_SCRAPE_URI", "http://broker:8080")
+	t.Setenv("SOLACE_USERNAME", "monitor")
+	t.Setenv("SOLACE_PASSWORD", "secret")
+
+	endpoints, conf, err := ParseConfig("")
+	if err != nil {
+		t.Fatalf("ParseConfig error: %v", err)
+	}
+	if conf.authType != AuthTypeBasic {
+		t.Errorf("authType = %v, want AuthTypeBasic", conf.authType)
+	}
+	if conf.oAuthToken == nil {
+		t.Error("oAuthToken cache must be initialised by ParseConfig (prevents nil panic on OAuth)")
+	}
+	if conf.ScrapeURI != "http://broker:8080" || conf.Username != "monitor" || conf.Password != "secret" {
+		t.Errorf("unexpected creds/uri: %+v", struct{ U, P, S string }{conf.Username, conf.Password, conf.ScrapeURI})
+	}
+	// defaults
+	if conf.Timeout != 5*time.Second {
+		t.Errorf("default Timeout = %v, want 5s", conf.Timeout)
+	}
+	if conf.SempPageSize != 100 {
+		t.Errorf("default SempPageSize = %d, want 100", conf.SempPageSize)
+	}
+	if len(endpoints) != 0 {
+		t.Errorf("expected no endpoints without a config file, got %v", endpoints)
+	}
+}
+
+func TestParseConfigOAuthFromEnv(t *testing.T) {
+	clearSolaceEnv(t)
+	t.Setenv("SOLACE_SCRAPE_URI", "http://broker:8080")
+	t.Setenv("SOLACE_OAUTH_TOKEN_URL", "http://idp/token")
+	t.Setenv("SOLACE_OAUTH_CLIENT_ID", "cid")
+	t.Setenv("SOLACE_OAUTH_CLIENT_SECRET", "csecret")
+	t.Setenv("SOLACE_OAUTH_CLIENT_SCOPE", "scope")
+
+	_, conf, err := ParseConfig("")
+	if err != nil {
+		t.Fatalf("ParseConfig error: %v", err)
+	}
+	if conf.authType != AuthTypeOAuth {
+		t.Errorf("authType = %v, want AuthTypeOAuth", conf.authType)
+	}
+	if conf.oAuthToken == nil {
+		t.Error("oAuthToken cache must be initialised for OAuth config")
+	}
+}
+
+func TestParseConfigPartialOAuthFails(t *testing.T) {
+	clearSolaceEnv(t)
+	t.Setenv("SOLACE_SCRAPE_URI", "http://broker:8080")
+	// Only some OAuth fields set: this must fail loudly rather than silently using default admin/admin basic auth.
+	t.Setenv("SOLACE_OAUTH_TOKEN_URL", "http://idp/token")
+	t.Setenv("SOLACE_OAUTH_CLIENT_ID", "cid")
+	// missing SOLACE_OAUTH_CLIENT_SECRET and SOLACE_OAUTH_CLIENT_SCOPE
+
+	if _, _, err := ParseConfig(""); err == nil {
+		t.Fatal("expected error for partially configured OAuth, got nil")
+	}
+}
+
+func TestParseConfigMissingScrapeURIFails(t *testing.T) {
+	clearSolaceEnv(t)
+	t.Setenv("SOLACE_USERNAME", "monitor")
+	t.Setenv("SOLACE_PASSWORD", "secret")
+
+	if _, _, err := ParseConfig(""); err == nil {
+		t.Fatal("expected error when scrapeUri is missing, got nil")
+	}
+}
+
+func TestParseConfigEndpointsFromIni(t *testing.T) {
+	clearSolaceEnv(t)
+	dir := t.TempDir()
+	iniPath := filepath.Join(dir, "solace.ini")
+	ini := `[solace]
+scrapeUri=http://broker:8080
+username=monitor
+password=secret
+
+[endpoint.std]
+Health=*|*
+Vpn=*|*
+`
+	if err := os.WriteFile(iniPath, []byte(ini), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	endpoints, conf, err := ParseConfig(iniPath)
+	if err != nil {
+		t.Fatalf("ParseConfig error: %v", err)
+	}
+	if conf.ScrapeURI != "http://broker:8080" {
+		t.Errorf("ScrapeURI = %q, want http://broker:8080", conf.ScrapeURI)
+	}
+	ds, ok := endpoints["std"]
+	if !ok {
+		t.Fatalf("endpoint 'std' not parsed, got %v", endpoints)
+	}
+	if len(ds) != 2 {
+		t.Errorf("endpoint 'std' has %d datasources, want 2 (%v)", len(ds), ds)
+	}
+}

--- a/internal/exporter/exporter.collect.go
+++ b/internal/exporter/exporter.collect.go
@@ -12,7 +12,7 @@ import (
 // CollectPrometheusMetric fetches the stats from configured Solace location and delivers them
 // as Prometheus metrics. It implements prometheus.Collector.
 func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
-	var up float64 = 1
+	var up float64 // set per dataSource in the switch below before it is read
 	var err error
 	var vpnName string
 
@@ -153,6 +153,7 @@ func (e *Exporter) CollectPrometheusMetric(ch chan<- semp.PrometheusMetric) {
 		case "QueueStats", "QueueStatsV1":
 			up, err = e.semp.GetQueueStatsSemp1(ch, dataSource.VpnFilter, dataSource.ItemFilter, e.config.SempPageSize)
 		case "QueueStatsV2":
+			up = 0 // reset before getVpnName so its failure isn't reported with the previous datasource's up value
 			vpnName, err = e.getVpnName(dataSource.VpnFilter)
 			if err == nil {
 				up, err = e.semp.GetQueueStatsSemp2(ch, vpnName, dataSource.ItemFilter, dataSource.MetricFilter)
@@ -208,8 +209,15 @@ func (e *Exporter) Collect(pch chan<- prometheus.Metric) {
 	wg.Add(1)
 
 	collectWorker := func() {
+		defer wg.Done()
+		// A malformed/unexpected broker reply must not crash the whole exporter (all brokers). Recover, log, and
+		// let this scrape simply report fewer metrics.
+		defer func() {
+			if r := recover(); r != nil {
+				e.logger.Error("recovered from panic while scraping broker", "panic", r, "scrapeURI", e.config.ScrapeURI)
+			}
+		}()
 		e.CollectPrometheusMetric(ch)
-		wg.Done()
 	}
 	go collectWorker()
 

--- a/internal/semp/getMemorySemp1.go
+++ b/internal/semp/getMemorySemp1.go
@@ -79,7 +79,11 @@ func (semp *Semp) GetMemorySemp1(ch chan<- PrometheusMetric) (float64, error) {
 
 	ch <- semp.NewMetric(MetricDesc["Memory"]["system_memory_physical_usage_percent"], prometheus.GaugeValue, target.RPC.Show.Memory.PhysicalUsagePercent)
 	ch <- semp.NewMetric(MetricDesc["Memory"]["system_memory_subscription_usage_percent"], prometheus.GaugeValue, target.RPC.Show.Memory.SubscriptionUsagePercent)
-	ch <- semp.NewMetric(MetricDesc["Memory"]["system_nab_buffer_load_factor"], prometheus.GaugeValue, target.RPC.Show.Memory.SlotInfos.SlotInfo[0].NabBufLoadFactor)
+	// SlotInfo may be empty on software/cloud brokers or malformed replies; guard the index to avoid a panic that
+	// would crash the whole exporter for every broker.
+	if slotInfos := target.RPC.Show.Memory.SlotInfos.SlotInfo; len(slotInfos) > 0 {
+		ch <- semp.NewMetric(MetricDesc["Memory"]["system_nab_buffer_load_factor"], prometheus.GaugeValue, slotInfos[0].NabBufLoadFactor)
+	}
 
 	return 1, nil
 }

--- a/internal/semp/getMemorySemp1_test.go
+++ b/internal/semp/getMemorySemp1_test.go
@@ -1,0 +1,93 @@
+package semp
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func memoryReply(slotInfos string) string {
+	return `<rpc-reply semp-version="soltr/9_1_1VMR"><rpc><show><memory>` +
+		`<physical-memory><memory-info><type>Memory</type><total-in-kb>100</total-in-kb>` +
+		`<used-in-kb>40</used-in-kb><free-in-kb>60</free-in-kb><buffers-in-kb>1</buffers-in-kb>` +
+		`<cached-in-kb>2</cached-in-kb></memory-info></physical-memory>` +
+		`<physical-memory-usage-percent>40</physical-memory-usage-percent>` +
+		`<subscription-memory-usage-percent>10</subscription-memory-usage-percent>` +
+		slotInfos +
+		`</memory></show></rpc><execute-result code="ok"/></rpc-reply>`
+}
+
+func newMemoryTestSemp(t *testing.T, reply string) *Semp {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(reply))
+	}))
+	t.Cleanup(server.Close)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return NewSemp(logger, server.URL, http.Client{}, nil, false, false)
+}
+
+func drain(ch chan PrometheusMetric) []PrometheusMetric {
+	close(ch)
+	var out []PrometheusMetric
+	for m := range ch {
+		out = append(out, m)
+	}
+	return out
+}
+
+// TestGetMemorySemp1EmptySlotInfoNoPanic guards the fix for the index-out-of-range panic on brokers that report no
+// slot-info (software/cloud brokers). Such a panic in the detached scrape goroutine crashed the whole exporter.
+func TestGetMemorySemp1EmptySlotInfoNoPanic(t *testing.T) {
+	t.Parallel()
+	s := newMemoryTestSemp(t, memoryReply(`<slot-infos></slot-infos>`))
+
+	ch := make(chan PrometheusMetric, 100)
+	up, err := s.GetMemorySemp1(ch) // must not panic
+	metrics := drain(ch)
+
+	if err != nil {
+		t.Fatalf("GetMemorySemp1 error: %v", err)
+	}
+	if up != 1 {
+		t.Errorf("up = %v, want 1", up)
+	}
+	if len(metrics) == 0 {
+		t.Error("expected physical-memory metrics to be emitted even without slot-info")
+	}
+	for _, m := range metrics {
+		if strings.Contains(m.Name(), "nab_buffer_load_factor") {
+			t.Errorf("nab_buffer_load_factor must be skipped when slot-info is empty, got %s", m.Name())
+		}
+	}
+}
+
+// TestGetMemorySemp1WithSlotInfo verifies the nab-buffer-load-factor metric is emitted when slot-info is present.
+func TestGetMemorySemp1WithSlotInfo(t *testing.T) {
+	t.Parallel()
+	s := newMemoryTestSemp(t, memoryReply(`<slot-infos><slot-info><slot>1</slot><nab-buffer-load-factor>0.5</nab-buffer-load-factor></slot-info></slot-infos>`))
+
+	ch := make(chan PrometheusMetric, 100)
+	up, err := s.GetMemorySemp1(ch)
+	metrics := drain(ch)
+
+	if err != nil {
+		t.Fatalf("GetMemorySemp1 error: %v", err)
+	}
+	if up != 1 {
+		t.Errorf("up = %v, want 1", up)
+	}
+	found := false
+	for _, m := range metrics {
+		if strings.Contains(m.Name(), "nab_buffer_load_factor") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected nab_buffer_load_factor metric when slot-info is present")
+	}
+}

--- a/internal/semp/http.go
+++ b/internal/semp/http.go
@@ -20,7 +20,9 @@ func (semp *Semp) postHTTP(uri string, _ string, body string, logName string, pa
 		return nil, err
 	}
 
-	semp.httpRequestVisitor(req)
+	if semp.httpRequestVisitor != nil {
+		semp.httpRequestVisitor(req)
+	}
 
 	resp, err := semp.httpClient.Do(req)
 	if err != nil {
@@ -48,12 +50,17 @@ func (semp *Semp) getHTTPbytes(uri string, _ string, logName string, page int) (
 		return nil, err
 	}
 
-	semp.httpRequestVisitor(req)
+	if semp.httpRequestVisitor != nil {
+		semp.httpRequestVisitor(req)
+	}
 
 	resp, err := semp.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	// Always close the body: previously it was only closed on the >=500 path, leaking a connection on every
+	// successful SEMP v2 page.
+	defer func() { _ = resp.Body.Close() }()
 
 	var queryDuration = time.Since(start)
 	if semp.logBrokerToSlowWarnings && (page > 1 && queryDuration > longQuery) || (page == 1 && queryDuration > longQueryFirstSempV2) {
@@ -63,7 +70,6 @@ func (semp *Semp) getHTTPbytes(uri string, _ string, logName string, page int) (
 	semp.logger.Debug("Scraped "+logName, "page", page, "duration", queryDuration)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 500 {
-		_ = resp.Body.Close()
 		return nil, fmt.Errorf("HTTP status %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 

--- a/internal/semp/http_test.go
+++ b/internal/semp/http_test.go
@@ -1,0 +1,92 @@
+package semp
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func newHTTPTestSemp(t *testing.T, status int, body string) *Semp {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return NewSemp(logger, server.URL, http.Client{}, nil, false, false)
+}
+
+func TestPostHTTPSuccess(t *testing.T) {
+	t.Parallel()
+	s := newHTTPTestSemp(t, http.StatusOK, "<ok/>")
+	rc, err := s.postHTTP(s.brokerURI+"/SEMP", "application/xml", "<rpc/>", "Test", 1)
+	if err != nil {
+		t.Fatalf("postHTTP error: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	b, _ := io.ReadAll(rc)
+	if string(b) != "<ok/>" {
+		t.Errorf("body = %q, want <ok/>", string(b))
+	}
+}
+
+func TestPostHTTPStatusErrors(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusUnauthorized, http.StatusInternalServerError} {
+		s := newHTTPTestSemp(t, status, "boom")
+		rc, err := s.postHTTP(s.brokerURI+"/SEMP", "application/xml", "<rpc/>", "Test", 1)
+		if err == nil {
+			_ = rc.Close()
+			t.Errorf("postHTTP status %d: expected error, got nil", status)
+		}
+		if rc != nil {
+			t.Errorf("postHTTP status %d: expected nil body on error", status)
+		}
+	}
+}
+
+func TestGetHTTPbytesSuccessAndClientError(t *testing.T) {
+	t.Parallel()
+	// 200 -> body returned
+	s := newHTTPTestSemp(t, http.StatusOK, `{"ok":true}`)
+	b, err := s.getHTTPbytes(s.brokerURI, "application/json", "Test", 1)
+	if err != nil {
+		t.Fatalf("getHTTPbytes 200 error: %v", err)
+	}
+	if string(b) != `{"ok":true}` {
+		t.Errorf("body = %q", string(b))
+	}
+
+	// 4xx -> body still returned (SEMP v2 returns error detail in a 400 body, which the caller parses)
+	s = newHTTPTestSemp(t, http.StatusBadRequest, `{"error":"bad"}`)
+	b, err = s.getHTTPbytes(s.brokerURI, "application/json", "Test", 1)
+	if err != nil {
+		t.Fatalf("getHTTPbytes 400 error: %v", err)
+	}
+	if string(b) != `{"error":"bad"}` {
+		t.Errorf("body = %q", string(b))
+	}
+}
+
+func TestGetHTTPbytesServerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	s := newHTTPTestSemp(t, http.StatusInternalServerError, "boom")
+	if _, err := s.getHTTPbytes(s.brokerURI, "application/json", "Test", 1); err == nil {
+		t.Error("getHTTPbytes 500: expected error, got nil")
+	}
+}
+
+// TestVisitorNilDoesNotPanic ensures a nil httpRequestVisitor (e.g. when auth setup failed) does not panic the scrape.
+func TestVisitorNilDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	s := newHTTPTestSemp(t, http.StatusOK, "<ok/>") // NewSemp called with nil visitor
+	rc, err := s.postHTTP(s.brokerURI+"/SEMP", "application/xml", "<rpc/>", "Test", 1)
+	if err != nil {
+		t.Fatalf("postHTTP with nil visitor error: %v", err)
+	}
+	_ = rc.Close()
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"net/http"
 	"solace_exporter/internal/exporter"
 )
@@ -13,9 +15,19 @@ func WrapWithAuth(handler http.Handler, authConf exporter.ExporterAuthConfig) ht
 }
 
 func basicAuth(h http.Handler, authConf exporter.ExporterAuthConfig) http.Handler {
+	// Compare fixed-size SHA-256 digests rather than the raw credentials. subtle.ConstantTimeCompare returns
+	// early when the two slices differ in length, so comparing the raw values would leak credential length via
+	// timing. Hashing first makes both operands a constant 32 bytes, so the comparison is constant-time with
+	// respect to both the content and the length of the supplied credentials.
+	wantUser := sha256.Sum256([]byte(authConf.Username))
+	wantPass := sha256.Sum256([]byte(authConf.Password))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, p, ok := r.BasicAuth()
-		if !ok || u != authConf.Username || p != authConf.Password {
+		gotUser := sha256.Sum256([]byte(u))
+		gotPass := sha256.Sum256([]byte(p))
+		userOK := subtle.ConstantTimeCompare(gotUser[:], wantUser[:]) == 1
+		passOK := subtle.ConstantTimeCompare(gotPass[:], wantPass[:]) == 1
+		if !ok || !userOK || !passOK {
 			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte("unauthorized\n"))


### PR DESCRIPTION
## Problem

The `/solace` HTTP handler mutated a single, process-wide `*exporter.Config` on every request — setting `Username`, `Password`, `ScrapeURI` and `Timeout` from the request — while the SEMP auth visitor read those same fields **later**, at scrape time.

Because Prometheus scrapes targets concurrently, one in-flight request can overwrite another request's credentials/URI in the shared config between the handler writing them and the SEMP call reading them. The visible symptom is intermittent **HTTP 401 (Unauthorized)** from many brokers at once under scrape concurrency, because a broker ends up being authenticated with a *different* target's password. Severity scales with the number of concurrent scrapes.

This is the same race that #`031d239` originally fixed by passing `Config` by value, and that `00600f0` reintroduced when it switched back to a shared pointer to keep the OAuth token cache warm.

## Fix

Reconcile per-request isolation with a warm token cache:

- Move the OAuth token cache into an `oAuthTokenCache` struct held **by pointer** in `Config`.
- Add `Config.Clone()` — a shallow copy that shares the cache pointer (not the mutex).
- The handler now builds a **per-request** config via `Clone()` and never mutates the shared base, so concurrent scrapes are fully isolated while the OAuth token stays cached across all requests.

A regression test (`TestConcurrentScrapesDoNotLeakCredentials`) fails under `-race` on the old code (torn credential reads) and passes on the fix.

## Additional hardening (found while reviewing the repo)

- **OAuth token staleness:** the OAuth visitor now reads the token from the cache on *every* request rather than capturing one token for its lifetime, so long-lived async fetchers pick up a refreshed token after expiry (a second source of 401s).
- **Never-nil auth visitor + nil-guard** in the SEMP client, so a token-fetch failure no longer panics the scrape.
- **Async (prefetch) endpoints** are now protected by the same basic-auth wrapper as the synchronous endpoints.
- **`getMemorySemp1`** guards `SlotInfo[0]` (empty slot-info no longer panics), and the collect goroutines `recover()` so a single panic can't crash the whole exporter for all targets.
- **`getHTTPbytes`** no longer leaks the response body on the success path.
- **`QueueStatsV2`** sets `up=0` when the VPN name can't be resolved.
- **`issuerPrefixedToken`** uses unpadded base64 (`RawStdEncoding`) instead of a fragile one-character strip that corrupted issuers with 0/2 padding characters.
- **Exporter basic-auth** uses constant-time comparison.
- **Partial OAuth configuration** now fails loudly instead of silently falling back.
- A **non-positive request timeout** keeps the configured timeout.

## Tests

New/expanded tests cover: concurrent credential isolation, OAuth caching and clone-sharing, config parsing (basic / OAuth / partial / ini), data-source parsing, end-to-end scrape auth (`up=1`/`up=0`), the memory empty-slot path, and SEMP HTTP status / nil-visitor handling.

Verification: `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), and `go test -race ./...` all pass.
