### PR TITLE
docs: expand README and add contributor/agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,204 @@
+# AGENTS.md
+
+Contributor and AI-agent guide for the **solace-prometheus-exporter** codebase. It captures the conventions,
+structure and invariants a change should respect. Read it alongside [`CONTRIBUTING.MD`](CONTRIBUTING.MD) and
+[`docs/CONFIG.md`](docs/CONFIG.md).
+
+## 1. Technology Stack
+
+* **Language:** Go (see `go` directive in [`go.mod`](go.mod); module name `solace_exporter`).
+* **Metrics:** `github.com/prometheus/client_golang` (the exporter implements `prometheus.Collector`).
+* **CLI / logging:** `github.com/alecthomas/kingpin/v2` for flags; `github.com/prometheus/common/promslog` +
+  `log/slog` for structured logging; `github.com/prometheus/common/version` for build info.
+* **Config:** `gopkg.in/ini.v1` for the INI file; `os.Getenv` for environment overrides.
+* **Auth / TLS:** `golang.org/x/oauth2/clientcredentials` for broker OAuth;
+  `software.sslmate.com/src/go-pkcs12` for PKCS#12 keystores; standard `crypto/tls`.
+* **Concurrency:** `golang.org/x/sync/semaphore` bounds concurrent SEMP connections.
+* **SEMP transport:** standard `net/http`, `encoding/xml` (SEMP v1), `encoding/json` (SEMP v2).
+* **Build & CI:** [`Makefile`](Makefile), multi-stage [`Dockerfile`](Dockerfile) producing a `scratch` image,
+  GitHub Actions running `golangci-lint`, `go mod tidy` checks and `go test`.
+
+## 2. Project Structure
+
+```
+cmd/solace-prometheus-exporter/   Entry point: flag parsing, HTTP handler wiring, /solace param parsing
+internal/exporter/                Config, the Exporter collector, per-request config, HTTP client, auth, TLS, async prefetch
+  config.struct.go                Config struct + ParseConfig (INI + env), endpoint alias parsing
+  exporter.struct.go              Exporter type; wires a *semp.Semp per request
+  exporter.collect.go             CollectPrometheusMetric: the scrape-target dispatch switch + Collect()
+  exporter.describe.go            Describe() over the metric registry
+  dataSource.struct.go            DataSource{Name, VpnFilter, ItemFilter, MetricFilter}
+  auth.go / http.go / tlsServer.go  OAuth/basic visitor, HTTP client, HTTPS listener
+  asyncFetcher.go                 Prefetch collector used when prefetchInterval > 0
+internal/semp/                    SEMP access layer
+  getXxxSemp1.go                  One file per SEMP v1 target (POST XML to /SEMP)
+  getQueueStatsSemp2.go           SEMP v2 target (GET JSON from /SEMP/v2/monitor/...)
+  metricDesc.go                   MetricDesc registry: label sets + all metric Descriptions
+  semp.desc.struct.go             Desc, Descriptions, V2Result, field-selection helpers
+  prometheusMetric.struct.go      PrometheusMetric wrapper (dedupe key, cardinality checks)
+  http.go / helper.go / types/    HTTP verbs, filter escaping, shared XML types
+internal/web/                     Index page handler/template + exporter Basic Auth wrapper
+configs/                          Sample INI config (also baked into the Docker image)
+docs/CONFIG.md                    Full settings + scrape-target reference
+examples/                         Grafana dashboards and an NGINX reverse-proxy Helm chart
+test/                             Captured SEMP fixtures (test/data) and an OAuth e2e stack (test/oauth)
+```
+
+## 3. Coding Standards & Conventions
+
+* **Formatting/linting:** code must be `gofmt`-clean and pass `golangci-lint run` (`make lint`). Keep imports
+  grouped (stdlib, then third-party) and use tabs for indentation.
+* **Logging:** use the injected `*slog.Logger` with key/value pairs (`logger.Error("msg", "err", err, "broker",
+  uri)`), not `fmt`/`log`. Do not `panic` in a scrape path (see §7).
+* **Errors:** wrap with `%w` (`fmt.Errorf("...: %w", err)`); return early. Config parsing returns
+  `(..., *Config, error)` and fails fast on invalid/incomplete input.
+* **Metrics namespace:** every metric name is prefixed with `solace_` — this is applied once in
+  `NewSemDesc` (do not repeat the prefix in call sites).
+* **Value types:** pick `prometheus.CounterValue` for monotonic counters and `prometheus.GaugeValue` for gauges
+  when emitting via `semp.NewMetric`.
+* **No magic values:** durations, page sizes and channel capacities are named constants (`longQuery`,
+  `capMetricChan`, `metricCacheChunkSize`, ...).
+* **Security exceptions:** the SEMP HTTP client intentionally uses `InsecureSkipVerify` (broker certs are often
+  self-signed); it is annotated `//nolint:gosec`. Do not remove the annotation without changing the behaviour.
+
+## 4. Scrape Handlers & SEMP Access
+
+* **Handler wiring (`main.go`):** `/metrics` serves process metrics; `/solace` parses `m.<Target>` GET params into
+  `[]exporter.DataSource`; each `[endpoint.<alias>]` config section becomes its own handler. Every handler is
+  wrapped with `web.WrapWithAuth` (exporter Basic Auth). When `prefetchInterval > 0`, alias handlers are served by
+  an `AsyncFetcher` from cache instead of scraping inline.
+* **Parameter grammar:** a `/solace` value is `vpnFilter|itemFilter[|metricFilter,...]`; fewer than two
+  `|`-separated parts is skipped/rejected with a log. The metric filter (third part) is SEMP v2 only.
+* **Dispatch (`exporter.collect.go`):** `CollectPrometheusMetric` switches on `DataSource.Name`. Each target has a
+  bare name and a `...V1` alias mapped to the same getter (e.g. `"VpnStats", "VpnStatsV1"`). Hardware-only and
+  software-only targets are gated on `e.config.IsHWBroker` and emit an explanatory error otherwise.
+* **SEMP v1 getters:** build an `<rpc><show>...</rpc>` command, `POST` it to `<brokerURI>/SEMP` via
+  `semp.postHTTP`, decode XML into a local `Data` struct, check `ExecuteResult.Result == "ok"`, then emit metrics.
+  Paged calls loop on `types.MoreCookie` using `<num-elements>` = `sempPageSize`.
+* **SEMP v2 getters:** `GET` `<brokerURI>/SEMP/v2/monitor/...` via `semp.getHTTPbytes`, decode JSON, check
+  `Meta.ResponseCode == 200`, follow `Meta.Paging.NextPageURI`. Field selection uses `select=`, filtering uses
+  `where=`. Unlike v1, v2 does **not** support `*` wildcards.
+* **Auth:** requests are decorated by `httpRequestVisitor` from `Config.setAuthHeader` — Basic Auth or an OAuth
+  bearer (optionally issuer-prefixed). The visitor is always non-nil.
+* **Return contract:** getters return `(up float64, err error)`: `up >= 1` success, `up == 0` recoverable failure
+  for this target, `up == -1` unrecoverable (e.g. broker unreachable) which aborts the remaining targets and is
+  reported under the `global` endpoint.
+
+## 5. Adding a Metric or Scrape Target
+
+To add or extend a target:
+
+1. **Describe the metrics** in `internal/semp/metricDesc.go`: add entries to an existing `Descriptions` block or a
+   new one, using `NewSemDesc(fqName, sempV2field, help, variableLabels)`, and register the block under a key in the
+   `MetricDesc` map. Reuse an existing `variableLabels...` slice where the label set matches.
+2. **Implement the getter** as `internal/semp/getXxxSemp1.go` (or a `...Semp2.go`), following the pattern in §4:
+   inner struct with `xml:`/`json:` tags, request, decode, result-code check, `ch <- semp.NewMetric(...)`, return
+   `(up, err)`.
+3. **Wire the dispatch** by adding a `case "Xxx", "XxxV1":` to the switch in `exporter.collect.go`, passing the
+   relevant `dataSource` filters and `e.config.SempPageSize`. Gate on `IsHWBroker` if the target is
+   hardware/software specific.
+4. **Document it** by adding a row to the "Supported Scrape Targets" table in `docs/CONFIG.md`, the table in
+   `internal/web/templates/index.html`, and the metric groups table in `README.md`.
+5. **Test it** with a captured payload fixture under `test/data` and a table-driven test (see §6).
+
+To add a new named endpoint, no code change is needed — add an `[endpoint.<name>]` section to the config file.
+
+## 6. Testing
+
+* **Run:** `make test` (`go test -short ./...`). Use `-short` to skip long/integration paths; `make test-coverage`
+  writes an HTML report to `reports/`.
+* **Style:** table-driven tests decode fixtures under `test/data` (e.g. `semp1-vpn.txt`, `semp2-queue.txt`) and
+  assert emitted metrics; shared helpers live in `helper_test.go`. Add a fixture for every new getter.
+* **Static checks:** `make vet` and `make lint` (golangci-lint) must pass. CI also runs `go mod tidy` and fails if
+  `go.mod`/`go.sum` change, so run `go mod tidy` after touching dependencies.
+* **End-to-end:** `test/oauth/docker-compose.yaml` spins up Keycloak + a Solace broker + a scrape check to exercise
+  the OAuth path; it runs in CI and can be run locally with Docker Compose.
+
+## 7. Project-Specific Patterns & Invariants
+
+* **Config isolation:** the shared base `*Config` is never mutated after startup. The `/solace` handler derives a
+  per-request `Config.Clone()` and overrides `Username`/`Password`/`ScrapeURI`/`Timeout` on the copy so concurrent
+  scrapes cannot clobber each other's credentials.
+* **Shared OAuth cache:** `Config.oAuthToken` is intentionally shared by pointer across clones so the token stays
+  warm; the token is read fresh from the cache on every request (it refreshes shortly before expiry).
+* **Never crash the process:** `Collect` and the async fetcher wrap `CollectPrometheusMetric` in `recover()` — a
+  malformed broker reply must degrade to fewer metrics, not take down the exporter (which may front many brokers).
+  The auth visitor must therefore always be non-nil.
+* **Deduplication:** `Collect` keeps a `map[string]PrometheusMetric` keyed by `PrometheusMetric.Name()` (fqName +
+  label values) and emits the last value per key. Two enabled targets that produce the same metric name with
+  different label sets collide — avoid combining them (see the metric-collision note in `docs/CONFIG.md`).
+* **Label cardinality:** `semp.NewMetric` panics if the number of label values differs from the `Desc`'s
+  `variableLabels`, or if a value is not valid UTF-8. Pass label values in the exact order of the label slice.
+* **`solace_up`:** emitted once per target with `error` and `endpoint` labels; `up == -1` is reported under
+  `endpoint="global"` and stops processing further targets.
+* **Prefetch semantics:** `AsyncFetcher` deprecates all cached metrics before each poll and deletes the ones not
+  refreshed, so stale series disappear. All prefetch endpoints honour the same exporter Basic Auth.
+* **Filters:** SEMP v1 supports `*` wildcards in VPN and item filters; SEMP v2 needs a concrete VPN (falling back to
+  `defaultVpn` when the filter is `*`) and uses `where=`/`select=` query filters instead.
+
+## 8. Example
+
+A minimal SEMP v1 target — metric description, getter and dispatch wiring:
+
+```go
+// internal/semp/metricDesc.go
+var Memory = Descriptions{
+    "physical_memory_usage_percent": NewSemDesc("system_memory_physical_usage_percent", NoSempV2Ready,
+        "Physical memory usage percentage.", nil),
+}
+// ... registered in the MetricDesc map:
+//   "Memory": Memory,
+```
+
+```go
+// internal/semp/getMemorySemp1.go
+func (semp *Semp) GetMemorySemp1(ch chan<- PrometheusMetric) (float64, error) {
+    type Data struct {
+        RPC struct {
+            Show struct {
+                Memory struct {
+                    PhysicalUsagePercent float64 `xml:"physical-memory-usage-percent"`
+                } `xml:"memory"`
+            } `xml:"show"`
+        } `xml:"rpc"`
+        ExecuteResult types.ExecuteResult `xml:"execute-result"`
+    }
+
+    body, err := semp.postHTTP(semp.brokerURI+"/SEMP", "application/xml",
+        "<rpc><show><memory/></show></rpc>", "MemorySemp1", 1)
+    if err != nil {
+        semp.logger.Error("Can't scrape MemorySemp1", "err", err, "broker", semp.brokerURI)
+        return -1, err // unrecoverable: broker unreachable
+    }
+    defer func() { _ = body.Close() }()
+
+    var target Data
+    if err := xml.NewDecoder(body).Decode(&target); err != nil {
+        return 0, err
+    }
+    if target.ExecuteResult.Result != "ok" {
+        return 0, errors.New("unexpected result: see log for details")
+    }
+
+    ch <- semp.NewMetric(MetricDesc["Memory"]["physical_memory_usage_percent"],
+        prometheus.GaugeValue, target.RPC.Show.Memory.PhysicalUsagePercent)
+    return 1, nil
+}
+```
+
+```go
+// internal/exporter/exporter.collect.go — inside the dispatch switch
+case "Memory", "MemoryV1":
+    up, err = e.semp.GetMemorySemp1(ch)
+```
+
+Scrape it via `http://<host>:9628/solace?m.Memory=*|*`, or add `Memory = *|*` to an `[endpoint.<alias>]` section.
+
+## Related Projects
+
+Public ecosystem projects this exporter integrates with:
+
+* [Prometheus](https://prometheus.io/) — scrapes and stores the exposed metrics.
+* [Grafana](https://grafana.com/) — dashboards for the metrics (see [`examples/grafana`](examples/grafana)).
+* [Solace PubSub+ & the SEMP API](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) — the monitored broker and its
+  management protocol.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,29 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![Go Report Card](https://goreportcard.com/badge/github.com/solacecommunity/solace-prometheus-exporter)](https://goreportcard.com/report/github.com/solacecommunity/solace-prometheus-exporter)
 
-The community-led standard for real-time observability and monitoring of Solace Event Brokers.
+The community-led standard for real-time observability and monitoring of Solace PubSub+ Event Brokers.
 
 ![Architecture overview](https://raw.githubusercontent.com/solacecommunity/solace-prometheus-exporter/master/docs/architecture_001.png)
 
-## 🚀 Quick Start
+## Overview
 
-The fastest way to get visibility into your Solace Broker is using Docker:
+`solace-prometheus-exporter` is a standalone [Prometheus](https://prometheus.io/) exporter, written in Go, that
+scrapes the [SEMP](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) (Solace Element Management Protocol) API of a
+Solace PubSub+ broker and exposes the results as Prometheus metrics over HTTP.
+
+The exporter sits between your brokers and your monitoring stack:
+
+* It talks to the broker over **SEMP v1** (XML over `POST /SEMP`) and **SEMP v2 monitor** (JSON over
+  `GET /SEMP/v2/monitor/...`), using Basic Auth or OAuth 2.0 client credentials.
+* It publishes broker, VPN, queue, client, bridge and hardware metrics on port **9628**, ready to be scraped by
+  Prometheus and visualised in [Grafana](https://grafana.com/) (ready-made dashboards ship in
+  [`examples/grafana`](examples/grafana)).
+* Instead of one fixed metric set, it exposes a **modular `/solace` endpoint** plus named endpoint aliases, so each
+  Prometheus scrape job can request exactly the data it needs and keep broker load under control.
+
+## Quick Start
+
+The fastest way to get visibility into your Solace broker is with Docker:
 
 ```bash
 docker run -d \
@@ -20,74 +36,352 @@ docker run -d \
   solacecommunity/solace-prometheus-exporter
 ```
 
-Access your metrics immediately at http://localhost:9628/solace-std
+Then scrape a bundled endpoint, for example the system + VPN standard set:
 
-## ✨ Key Features
-* **Modular Scraping**: Use the `/solace` endpoint with GET parameters to fetch exactly what you need, saving broker resources.
+```
+http://localhost:9628/solace-std
+```
 
-* **Enterprise Security**: Full support for TLS encryption, OAuth 2.0, and mTLS authentication.
+## Features
 
-* **Cloud-Native Ready**: Optimized for Docker and Kubernetes environments with native [Prometheus port registration](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) (9628).
+* **Modular scraping** &mdash; the `/solace` endpoint takes HTTP GET parameters so a scrape can request exactly the
+  metrics it needs, avoiding expensive broker queries.
+* **Named endpoint aliases** &mdash; group frequently used scrape targets into short, reusable URLs
+  (`[endpoint.<name>]` sections in the config file).
+* **SEMP v1 and SEMP v2** &mdash; over 40 scrape targets covering system, VPN, queue, client, bridge, RDP and
+  hardware statistics.
+* **Software and appliance brokers** &mdash; hardware-only targets (disk, RAID, environment, alarms) are enabled
+  with a single `isHWBroker` flag.
+* **Flexible authentication** &mdash; Basic Auth or OAuth 2.0 client-credentials to the broker, with an optional
+  issuer-prefixed bearer token.
+* **TLS everywhere** &mdash; serve metrics over HTTPS (PEM or PKCS#12) and optionally protect the exporter's own
+  endpoints with Basic Auth.
+* **Multi-broker friendly** &mdash; override the target broker, credentials and timeout per request via URL
+  parameters or `x-solace-broker-*` headers, so one exporter can front many brokers.
+* **Async prefetch** &mdash; optionally poll the broker on a fixed interval and serve cached metrics, smoothing out
+  load on slow brokers or very large result sets.
+* **Cloud-native** &mdash; small static binary, `scratch`-based container image, and a
+  [registered Prometheus default port](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) (9628).
 
+## Endpoints & Scrape Modes
 
-## 🛠 Configuration
-```plaintext
-solace_prometheus_exporter -h
+Once running, the exporter serves the following HTTP endpoints:
+
+| Endpoint                | Description                                                                                       |
+|-------------------------|---------------------------------------------------------------------------------------------------|
+| `/`                     | Landing page listing all configured endpoints.                                                    |
+| `/metrics`              | The exporter's own process metrics (Go runtime and standard Prometheus metrics).                  |
+| `/solace`               | The modular endpoint. Scrape targets are supplied as `m.<Target>` GET parameters (see below).     |
+| `/<alias>`              | One handler per `[endpoint.<alias>]` section defined in the config file.                           |
+
+The bundled sample config (`configs/solace_prometheus_exporter.ini`) predefines these aliases:
+`solace-std`, `solace-std-appliance`, `solace-det`, `solace-broker-std`, `solace-broker-std-appliance`,
+`solace-vpn-std`, `solace-vpn-stats`, `solace-vpn-det` and `solace-vpn-rdp`.
+
+### The modular `/solace` endpoint
+
+Each scrape target is passed as a GET parameter whose key is `m.<Target>` and whose value has **two or three**
+pipe-delimited parts:
+
+```
+m.<Target>=<vpnFilter>|<itemFilter>[|<metricFilter>]
+```
+
+1. **VPN filter** &mdash; `*` wildcards supported on SEMP v1 targets.
+2. **Item filter** &mdash; `*` wildcards on SEMP v1; SEMP v2 targets accept concrete names or `where=` filters.
+3. **Metric filter** &mdash; SEMP v2 only; a comma-separated allow-list of fields to limit the returned columns.
+
+Examples:
+
+```bash
+# Queue stats for all queues starting with BRAVO in VPN "myVpn"
+http://localhost:9628/solace?m.QueueStats=myVpn|BRAVO*
+
+# Reproduce the legacy "det" set for a single VPN
+http://localhost:9628/solace?m.ClientStats=myVpn|*&m.VpnStats=myVpn|*&m.BridgeStats=myVpn|*&m.QueueRates=myVpn|*&m.QueueDetails=myVpn|*
+
+# Point a single scrape at a different broker
+http://localhost:9628/solace?m.VpnStats=*|*&scrapeURI=http://another-broker:8080&username=monitoring&password=monitoring
+```
+
+Targets are dispatched case-sensitively; each also has a `...V1` alias (for example `VpnStats` and `VpnStatsV1`
+are equivalent). See the [Configuration Guide](docs/CONFIG.md) for the full list of targets, their filter support
+and the SEMP CLI command each one maps to.
+
+### Per-request broker overrides
+
+For the four connection fields below, the value is resolved as **URL parameter → HTTP header → configured value**,
+so one exporter instance can be reused as a generic proxy in front of many brokers:
+
+| URL parameter | HTTP header                 | Overrides            |
+|---------------|-----------------------------|----------------------|
+| `username`    | `x-solace-broker-username`  | Broker Basic Auth user |
+| `password`    | `x-solace-broker-password`  | Broker Basic Auth password |
+| `scrapeURI`   | `x-solace-broker-scrapeuri` | Broker SEMP base URI |
+| `timeout`     | `x-solace-broker-timeout`   | Per-request timeout (e.g. `10s`) |
+
+## Configuration
+
+The exporter is configured through an INI **config file**, **environment variables**, and (for the dynamic scrape
+fields) **URL parameters / HTTP headers**. Environment variables take precedence over the config file; the four
+connection fields above can additionally be overridden per request. Point the exporter at a config file with:
+
+```
+solace_prometheus_exporter --config-file=configs/solace_prometheus_exporter.ini
+```
+
+### Command-line flags
+
+```
 usage: solace_prometheus_exporter [<flags>]
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
-      --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
-      --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
-      --config-file=CONFIG-FILE  Path and name of config file. See sample file solace_prometheus_exporter.ini.
+  -h, --help                     Show context-sensitive help.
+      --log.level=info           Log level: one of [debug, info, warn, error].
+      --log.format=logfmt        Log output format: one of [logfmt, json].
+      --config-file=CONFIG-FILE  Path to the INI config file (see configs/solace_prometheus_exporter.ini).
 ```
 
-The exporter can be configured via **Environment Variables**, a **Config File** (`.ini`), or **URL Parameters**.
+### The `[solace]` section
 
-Check out the [Configuration Guide](https://github.com/solacecommunity/solace-prometheus-exporter/blob/master/docs/CONFIG.md) for all settings.
-## 🧩 The Modular Endpoint
-The broker provides the following endpoints:
+The global broker and listener settings live in the `[solace]` section. Each key can be overridden by the
+corresponding environment variable:
 
-```plaintext
-http://<host>:<port>/                    Document page showing list of endpoints
-http://<host>:<port>/metrics             Golang and standard Prometheus metrics
-http://<host>:<port>/solace-std          legacy, via config: Solace metrics for System and VPN levels
-http://<host>:<port>/solace-det          legacy, via config: Solace metrics for Messaging Clients and Queues
-http://<host>:<port>/solace-broker-std   legacy, via config: Solace Broker only Standard Metrics (System)
-http://<host>:<port>/solace-vpn-std      legacy, via config: Solace Vpn only Standard Metrics (VPN), available to non-global access right admins
-http://<host>:<port>/solace-vpn-stats    legacy, via config: Solace Vpn only Statistics Metrics (VPN), available to non-global access right admins
-http://<host>:<port>/solace-vpn-det      legacy, via config: Solace Vpn only Detailed Metrics (VPN), available to non-global access right admins
-http://<host>:<port>/solace              The modular endpoint
+| Environment variable                | Config key                | Default        | Description |
+|-------------------------------------|---------------------------|----------------|-------------|
+| `SOLACE_LISTEN_ADDR`                | `listenAddr`              | `0.0.0.0:9628` | Address the exporter listens on. |
+| `SOLACE_SCRAPE_URI`                 | `scrapeUri`               | *(required)*   | Base URI of the broker's SEMP interface, e.g. `http://localhost:8080`. |
+| `SOLACE_USERNAME`                   | `username`                | `admin`        | Basic Auth username for SEMP requests. |
+| `SOLACE_PASSWORD`                   | `password`                | `admin`        | Basic Auth password for SEMP requests. |
+| `SOLACE_DEFAULT_VPN`                | `defaultVpn`              | `default`      | Message VPN used for SEMP v2 targets when the VPN filter is `*`. |
+| `SOLACE_TIMEOUT`                    | `timeout`                 | `5s`           | Timeout for SEMP requests to the broker. |
+| `SOLACE_SSL_VERIFY`                 | `sslVerify`               | `false`        | Verify the broker's TLS certificate when scraping. |
+| `SOLACE_IS_HW_BROKER`              | `isHWBroker`              | `false`        | Enable appliance (hardware) targets and disable software-only ones. |
+| `SOLACE_SEMP_PAGE_SIZE`             | `sempPageSize`            | `100`          | Elements per SEMP v1 paging request. |
+| `SOLACE_PARALLEL_SEMP_CONNECTIONS`  | `parallelSempConnections` | `1`            | Maximum concurrent SEMP connections to the broker (Solace advises ≤10 per second). |
+| `PREFETCH_INTERVAL`                 | `prefetchInterval`        | `0s`           | If > 0, configured endpoints are fetched asynchronously on this interval and served from cache. |
+| `SOLACE_LOG_BROKER_IS_SLOW_WARNING` | `logBrokerToSlowWarnings` | `true`         | Log a warning when a SEMP query takes unusually long. |
+
+#### Serving over TLS
+
+| Environment variable       | Config key    | Default | Description |
+|----------------------------|---------------|---------|-------------|
+| `SOLACE_LISTEN_TLS`        | `enableTLS`   | `false` | Serve the exporter over HTTPS. |
+| `SOLACE_LISTEN_CERTTYPE`   | `certType`    | `PEM`   | Certificate type: `PEM` or `PKCS12`. |
+| `SOLACE_SERVER_CERT`       | `certificate` | -       | Path to the server certificate (PEM), including intermediates. |
+| `SOLACE_PRIVATE_KEY`       | `privateKey`  | -       | Path to the private key (PEM). |
+| `SOLACE_PKCS12_FILE`       | `pkcs12File`  | -       | Path to the PKCS#12 keystore. |
+| `SOLACE_PKCS12_PASS`       | `pkcs12Pass`  | -       | Password for the PKCS#12 keystore. |
+
+When TLS is enabled the exporter also sets HSTS and standard hardening headers (`X-Content-Type-Options`,
+`X-Frame-Options`, `Referrer-Policy`).
+
+#### OAuth 2.0 client credentials (broker auth)
+
+Set all four fields to authenticate to the broker with an OAuth 2.0 client-credentials flow instead of Basic Auth;
+tokens are cached and refreshed automatically. An incomplete OAuth configuration is rejected at startup.
+
+| Environment variable          | Config key           | Description |
+|-------------------------------|----------------------|-------------|
+| `SOLACE_OAUTH_TOKEN_URL`      | `oAuthTokenURL`      | Token endpoint URL. |
+| `SOLACE_OAUTH_CLIENT_ID`      | `oAuthClientID`      | OAuth client ID. |
+| `SOLACE_OAUTH_CLIENT_SECRET`  | `oAuthClientSecret`  | OAuth client secret. |
+| `SOLACE_OAUTH_CLIENT_SCOPE`   | `oAuthClientScope`   | OAuth scope. |
+| `SOLACE_OAUTH_ISSUER`         | `oAuthIssuer`        | Optional issuer; when set, the bearer token is issuer-prefixed as `~<base64(issuer)>~<token>`. |
+
+#### Protecting the exporter's own endpoints
+
+| Environment variable            | Config key             | Default | Description |
+|---------------------------------|------------------------|---------|-------------|
+| `SOLACE_EXPORTER_AUTH_SCHEME`   | `exporterAuthScheme`   | `none`  | `none` or `basic`. Enables Basic Auth on the exporter's HTTP endpoints. |
+| `SOLACE_EXPORTER_AUTH_USERNAME` | `exporterAuthUsername` | -       | Basic Auth username for the exporter. |
+| `SOLACE_EXPORTER_AUTH_PASSWORD` | `exporterAuthPassword` | -       | Basic Auth password for the exporter. |
+
+### Endpoint alias sections
+
+Named endpoints keep Prometheus scrape URLs short. Each key is a scrape target and its value uses the same
+`vpnFilter|itemFilter[|metricFilter]` syntax as the `/solace` parameters:
+
+```ini
+[endpoint.solace-custom]
+ClientStats = *|*
+VpnStats    = *|*
 ```
 
-The `/solace` endpoint is the most flexible way to scrape data. You can filter by VPN, Item, and even specific Metrics.
+The example above is served at `http://<host>:9628/solace-custom`. To use the same target more than once (for
+example with different item filters), suffix the key with `.<n>`:
 
-### Example: Get specific queue stats for a single VPN
-`http://localhost:9628/solace?m.QueueStats=myVpn|BRAVO*`
+```ini
+[endpoint.my-sample]
+QueueRates.0 = *|internal*
+QueueRates.1 = *|bridge_*
+```
 
-### Supported Scrape Targets (Shortlist)
-The exporter supports over 30 targets, including:
-* System: Health, Version, Disk, Memory, Redundancy.
-* VPN: VpnStats, BridgeStats, VpnSpool.
-* Clients: ClientStats, ClientConnections, SlowSubscriber.
-* Queues: QueueStats, QueueDetails, QueueStatsV2.
+See [`docs/CONFIG.md`](docs/CONFIG.md) for the complete settings reference, the SEMP v1 vs v2 comparison, and the
+metric-collision notes.
 
-For a full list of all targets and their CLI equivalents, see the [Configuration Guide](https://github.com/solacecommunity/solace-prometheus-exporter/blob/master/docs/CONFIG.md).
+## Metrics
 
-## 🤝 Contributing & Development
-We welcome contributions! Whether it's a bug report, a new feature, or improved documentation. If you want to build the exporter from source or contribute code:
+Every exported series is prefixed with `solace_`. Metrics are grouped into families, each produced by a scrape
+target:
 
-### Local Build
-1. Clone the repo
-1. Run `make build`
-1. Run with `./bin/solace_prometheus_exporter --config-file=your_config.ini`
+| Group            | Example scrape targets                                                             | What it covers |
+|------------------|------------------------------------------------------------------------------------|----------------|
+| Broker / system  | `Version`, `Health`, `Memory`, `Spool`, `SpoolStats`, `GlobalStats`, `GlobalSystemInfo`, `Interface` | Broker version and uptime, health, memory, message-spool usage, global client stats, NICs. |
+| Redundancy / DR  | `Redundancy`, `ConfigSync`, `ConfigSyncRouter`, `ReplicationStats`                 | HA redundancy, config-sync state, replication (DR) statistics. |
+| Appliance hardware | `Disk`, `Raid`, `Environment`, `Hardware`, `Alarm`, `ClockDetail`, `InterfaceHW` | Hardware-only metrics (enabled via `isHWBroker`). |
+| Message VPN      | `Vpn`, `VpnStats`, `VpnSpool`, `VpnReplication`, `ConfigSyncVpn`                   | Per-VPN state, throughput, spool usage and replication. |
+| Clients          | `Client`, `ClientStats`, `ClientConnections`, `ClientProfile`, `ClientSlowSubscriber`, `ClientMessageSpoolStats`, `ClientMessageSpoolEgress` | Connected clients, per-client stats, slow subscribers, per-client spool usage. |
+| Queues           | `QueueStats`, `QueueStatsV2`, `QueueDetails`, `QueueRates` *(deprecated)*          | Spooled messages/bytes, discards, redelivery and other per-queue counters. |
+| Topic endpoints  | `TopicEndpointStats`, `TopicEndpointDetails`, `TopicEndpointRates` *(deprecated)*  | Per-topic-endpoint statistics and details. |
+| Bridges          | `Bridge`, `BridgeStats`, `BridgeDetail`, `BridgeRemote`, `BridgeClientCert`        | Bridge state, throughput, remote connections and client certificates. |
+| REST delivery    | `RdpInfo`, `RdpStats`, `RestConsumerStats`                                         | REST Delivery Point info/stats and REST consumer statistics. |
+| Cluster / MQTT   | `ClusterLinks`, `MqttSession`                                                      | Cluster link state and MQTT session details. |
 
-Please read the [Contribution Guide](CONTRIBUTING.MD) for our code of conduct and the process for submitting pull requests and issues.
+In addition, every scrape emits a `solace_up{error, endpoint}` gauge (`1` when the target scraped successfully, `0`
+otherwise) so you can alert on broker or target-level failures.
 
-## 📚 Resources
+> **Metric collisions:** some metrics (for example `solace_client_slow_subscriber`) are produced by more than one
+> target with different label sets. Avoid enabling colliding targets in the same scrape, or Prometheus will reject
+> the sample. See [`docs/CONFIG.md`](docs/CONFIG.md#-metric-collisions) for details.
+
+## Running
+
+### Binary
+
+```bash
+make build
+./bin/solace_prometheus_exporter --config-file=configs/solace_prometheus_exporter.ini
+```
+
+### Docker
+
+```bash
+docker run -d \
+  -p 9628:9628 \
+  -e SOLACE_SCRAPE_URI=http://<your-broker-ip>:8080 \
+  -e SOLACE_USERNAME=admin \
+  -e SOLACE_PASSWORD=admin \
+  solacecommunity/solace-prometheus-exporter
+```
+
+The image ships with the sample config at `/etc/solace/solace_prometheus_exporter.ini`. To supply your own, mount
+it over that path:
+
+```bash
+docker run -d -p 9628:9628 \
+  -v $(pwd)/my-config.ini:/etc/solace/solace_prometheus_exporter.ini \
+  solacecommunity/solace-prometheus-exporter
+```
+
+### Kubernetes
+
+A minimal Deployment and Service configured entirely through environment variables:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: solace-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: solace-exporter }
+  template:
+    metadata:
+      labels: { app: solace-exporter }
+    spec:
+      containers:
+        - name: exporter
+          image: solacecommunity/solace-prometheus-exporter
+          ports:
+            - containerPort: 9628
+          env:
+            - name: SOLACE_SCRAPE_URI
+              value: "http://your-broker:8080"
+            - name: SOLACE_USERNAME
+              value: "monitoring"
+            - name: SOLACE_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: solace-exporter, key: password }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: solace-exporter
+spec:
+  selector: { app: solace-exporter }
+  ports:
+    - port: 9628
+      targetPort: 9628
+```
+
+For large or multi-broker deployments, [`examples/nginx_reverse_proxy`](examples/nginx_reverse_proxy) provides a
+Helm chart that scales the exporter out behind NGINX and keeps broker credentials out of your Prometheus config.
+
+### Prometheus scrape config
+
+Point Prometheus at the endpoint you want and relabel the broker address, so credentials stay out of the scrape
+config and the broker name becomes the `instance` label:
+
+```yaml
+- job_name: 'solace-std'
+  scrape_interval: 15s
+  metrics_path: /solace-std
+  static_configs:
+    - targets:
+        - https://USER:PASSWORD@first-broker:943
+        - https://USER:PASSWORD@second-broker:943
+  relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: instance
+    - target_label: __address__
+      replacement: solace-exporter:9628
+```
+
+See [`examples/grafana/README.md`](examples/grafana/README.md) for more scrape patterns.
+
+## Grafana dashboards
+
+Ready-to-import dashboards for brokers, VPNs and bridges live in [`examples/grafana`](examples/grafana) (with PDF
+previews). Some panels require the
+[`flant-statusmap-panel`](https://grafana.com/grafana/plugins/flant-statusmap-panel/) plugin. The dashboards
+identify each broker via the `instance` label described above.
+
+## Building & Testing
+
+The project uses a standard Go toolchain and a `Makefile`:
+
+```bash
+make build          # build ./bin/solace_prometheus_exporter
+make test           # go test -short ./...
+make test-coverage  # write an HTML coverage report to reports/
+make vet            # go vet
+make lint           # golangci-lint run
+```
+
+Unit tests are table-driven against captured SEMP payloads under [`test/data`](test/data). An OAuth end-to-end
+suite (Keycloak + a Solace broker + a scrape check) is defined in
+[`test/oauth/docker-compose.yaml`](test/oauth) and runs in CI. Continuous integration lints, checks `go mod tidy`,
+runs the tests and publishes the Docker image.
+
+## Contributing
+
+Contributions are welcome, whether it is a bug report, a new scrape target, or improved documentation. Please read
+the [Contribution Guide](CONTRIBUTING.MD) and our [Code of Conduct](CODE_OF_CONDUCT.md). Questions about Solace
+technologies are also welcome in the [Solace community](https://solace.community).
+
+If you are adding a metric or scrape target, see [`AGENTS.md`](AGENTS.md) for the project's coding conventions and a
+step-by-step guide.
+
+## Resources
+
 * Video: [Integrating Prometheus and Grafana with Solace](https://youtu.be/72Wz5rrStAU?t=35)
 * Blog: [How to Use OAuth with solace-prometheus-exporter](https://dev.to/pascalre/securing-solace-metrics-how-to-use-oauth-with-solace-prometheus-exporter-2i6l)
 * Blog: [Your Solace Prometheus Exporter Deserves a Better Pipeline](https://dev.to/pascalre/your-solace-prometheus-exporter-deserves-a-better-pipeline-3i6i)
 
 ## License
-Distributed under [MIT](LICENSE).
+
+Distributed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
Documentation-only update: substantially expands the README and adds an `AGENTS.md` contributor/agent guide. No code changes.

### README
- Restructured into: Overview, Quick Start, Features, Endpoints & scrape modes (`/`, `/metrics`, `/solace`, the alias handlers and the `m.<Target>=vpn|item|metric` query grammar, per-request `x-solace-broker-*` overrides), Configuration (CLI flags, `[solace]` settings, TLS, broker OAuth, exporter self-auth, endpoint alias sections), Metrics (the real metric families keyed to scrape targets), Running (binary, Docker, Kubernetes, Prometheus scrape config), Grafana dashboards, Building & testing.
- Content was derived from the code (handler wiring, the collect dispatch, the `MetricDesc` groups, config parsing). Existing badges, architecture image, Grafana references and license are preserved.
- Where the README now differs from `docs/CONFIG.md`, it reflects the actual code behaviour (e.g. `enableTLS` defaults to `false`; environment variables override the INI file).

### AGENTS.md (new)
A contributor / AI-agent guide for this repository: technology stack, project structure, Go coding standards as used here, the scrape handlers & SEMP access, how to add a metric or endpoint, testing, invariants, and a worked example.
