### PR TITLE
Add missing fibre_channel_state value for N_Port to N_Port connections

### DIFF
--- a/internal/semp/getHardwareSemp1.go
+++ b/internal/semp/getHardwareSemp1.go
@@ -74,7 +74,7 @@ func (semp *Semp) GetHardwareSemp1(ch chan<- PrometheusMetric) (float64, error) 
 		case "Host Bus Adapter Blade":
 			for _, FC := range slot.FibreChannel {
 				ch <- semp.NewMetric(MetricDesc["Hardware"]["fibre_channel_operational_state"], prometheus.GaugeValue, encodeMetricMulti(FC.OperationalState, []string{"Linkdown", "Online"}), FC.Number)
-				ch <- semp.NewMetric(MetricDesc["Hardware"]["fibre_channel_state"], prometheus.GaugeValue, encodeMetricMulti(FC.State, []string{"Link Down", "Link Up - F_Port (fabric via point-to-point)", "Link Up - Loop (private loop)"}), FC.Number)
+				ch <- semp.NewMetric(MetricDesc["Hardware"]["fibre_channel_state"], prometheus.GaugeValue, encodeMetricMulti(FC.State, []string{"Link Down", "Link Up - F_Port (fabric via point-to-point)", "Link Up - Loop (private loop)", "Link Up - N_Port to N_Port (direct nport connection)"}), FC.Number)
 			}
 			for _, LUN := range slot.ExternalDiskLun {
 				State := "Ready"

--- a/internal/semp/metricDesc.go
+++ b/internal/semp/metricDesc.go
@@ -348,7 +348,7 @@ var MetricDesc = map[string]Descriptions{
 	"Hardware": {
 		"operational_power_supplies":      NewSemDesc("operational_power_supplies", NoSempV2Ready, "Number of operational power supplies", nil),
 		"fibre_channel_operational_state": NewSemDesc("fibre_channel_operational_state", NoSempV2Ready, "Fibre channel operational state 0-Link Down 1-Online", variableLabelsHardwareFC),
-		"fibre_channel_state":             NewSemDesc("fibre_channel_state", NoSempV2Ready, "Fibre channel state 0-Link Down 1-Link Up, 2-Link Up Loop", variableLabelsHardwareFC),
+		"fibre_channel_state":             NewSemDesc("fibre_channel_state", NoSempV2Ready, "Fibre channel state 0-Link Down 1-Link Up, 2-Link Up Loop, 3-Link Up NPort", variableLabelsHardwareFC),
 		"external_disk_lun_state":         NewSemDesc("external_disk_lun_state", NoSempV2Ready, "External Disk LUN state 0-Offline 1-Ready", variableLabelsHardwareLUN),
 		"adb_operational_state":           NewSemDesc("adb_operational_state", NoSempV2Ready, "ADB Operational State, -1,0-Not OK 1-OK", nil),
 		"adb_flash_card_state":            NewSemDesc("adb_flash_card_state", NoSempV2Ready, "ADB Flash Card State, -1,0-Not OK 1-OK", nil),


### PR DESCRIPTION
## Summary

Adds `"Link Up - N_Port to N_Port (direct nport connection)"` as a valid state value for the `fibre_channel_state` metric.

## Problem

The `encodeMetricMulti` call for `fibre_channel_state` in `getHardwareSemp1.go` was missing this state, so hardware with a direct N_Port to N_Port connection wasn't reported correctly by the metric.

## Changes

- `internal/semp/getHardwareSemp1.go`: added the missing state string to the `fibre_channel_state` enum.