### PR TITLE
Add spool config and operational status metrics

### DIFF
--- a/internal/semp/getSpoolSemp1.go
+++ b/internal/semp/getSpoolSemp1.go
@@ -16,6 +16,8 @@ func (semp *Semp) GetSpoolSemp1(ch chan<- PrometheusMetric) (float64, error) {
 			Show struct {
 				Spool struct {
 					Info struct {
+						ConfigStatus                    string  `xml:"config-status"`
+						OperationalStatus               string  `xml:"operational-status"`
 						MessageCountUtilPercentage      string  `xml:"message-count-utilization-percentage"`
 						QuotaDiskUsage                  float64 `xml:"max-disk-usage"`
 						QuotaMsgCount                   string  `xml:"max-message-count"`
@@ -99,6 +101,9 @@ func (semp *Semp) GetSpoolSemp1(ch chan<- PrometheusMetric) (float64, error) {
 		)
 		return 0, err
 	}
+
+	ch <- semp.NewMetric(MetricDesc["Spool"]["system_spool_config_status"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Spool.Info.ConfigStatus, []string{"Disabled", "Enabled (Primary)", "Enabled (Backup)"}))
+	ch <- semp.NewMetric(MetricDesc["Spool"]["system_spool_operational_status"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Spool.Info.OperationalStatus, []string{"AD-Unknown", "AD-NotReady", "AD-Disabled", "AD-Activating", "AD-Active", "AD-Standby"}))
 
 	ch <- semp.NewMetric(MetricDesc["Spool"]["system_spool_quota_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.QuotaDiskUsage*1048576.0))
 	// MaxMsgCount is in the form "100M"

--- a/internal/semp/metricDesc.go
+++ b/internal/semp/metricDesc.go
@@ -162,6 +162,8 @@ var MetricDesc = map[string]Descriptions{
 		"system_clock_detail_ntp_server_reachable":        NewSemDesc("system_clock_detail_ntp_server_reachable", NoSempV2Ready, "Clock NTP Server Reachable? (0-no, 1-yes).", variableLabelsClockNTPAddr),
 	},
 	"Spool": {
+	    "system_spool_config_status":                       NewSemDesc("system_spool_config_status", NoSempV2Ready, "Spool config status (0-Disabled, 1-Enabled (Primary), 2-Enabled (Backup), -1-Undefined).", nil),
+        "system_spool_operational_status":                  NewSemDesc("system_spool_operational_status", NoSempV2Ready, "Spool operational status (0-AD-Unknown, 1-AD-NotReady, 2-AD-Disabled, 3-AD-Activating, 4-AD-Active, 5-AD-Standby, -1-Undefined).", nil),
 		"system_spool_quota_bytes":                         NewSemDesc("system_spool_quota_bytes", NoSempV2Ready, "Spool configured max disk usage.", nil),
 		"system_spool_quota_msgs":                          NewSemDesc("system_spool_quota_msgs", NoSempV2Ready, "Spool configured max number of messages.", nil),
 		"system_spool_disk_partition_usage_active_percent": NewSemDesc("system_spool_disk_partition_usage_active_percent", NoSempV2Ready, "Total disk usage in percent.", nil),


### PR DESCRIPTION
## Add spool config and operational status metrics

Added two new metrics to the existing `Spool` target to indicate whether the spool is actually *working*:

| Metric | Values |
|---|---|
| `solace_system_spool_config_status` | `0`-Disabled, `1`-Enabled (Primary), `2`-Enabled (Backup) |
| `solace_system_spool_operational_status` | `0`-AD-Unknown, `1`-AD-NotReady, `2`-AD-Disabled, `3`-AD-Activating, `4`-AD-Active, `5`-AD-Standby |
