### PR TITLE
Allow isHWBroker to be set per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ http://localhost:9628/solace-std
 * **SEMP v1 and SEMP v2** &mdash; over 40 scrape targets covering system, VPN, queue, client, bridge, RDP and
   hardware statistics.
 * **Software and appliance brokers** &mdash; hardware-only targets (disk, RAID, environment, alarms) are enabled
-  with a single `isHWBroker` flag.
+  with a single `isHWBroker` flag, settable globally or per request.
 * **Flexible authentication** &mdash; Basic Auth or OAuth 2.0 client-credentials to the broker, with an optional
   issuer-prefixed bearer token.
 * **TLS everywhere** &mdash; serve metrics over HTTPS (PEM or PKCS#12) and optionally protect the exporter's own
   endpoints with Basic Auth.
-* **Multi-broker friendly** &mdash; override the target broker, credentials and timeout per request via URL
-  parameters or `x-solace-broker-*` headers, so one exporter can front many brokers.
+* **Multi-broker friendly** &mdash; override the target broker, credentials, timeout and broker type per request via
+  URL parameters or `x-solace-broker-*` headers, so one exporter can front many brokers.
 * **Secret management** &mdash; plug in HashiCorp Vault (or a future backend) via `SECRET_BACKEND`; any credential
   field accepts a `vault:<path>#<field>` reference while plain text values pass through unchanged.
 * **Async prefetch** &mdash; optionally poll the broker on a fixed interval and serve cached metrics, smoothing out
@@ -112,7 +112,7 @@ and the SEMP CLI command each one maps to.
 
 ### Per-request broker overrides
 
-For the four connection fields below, the value is resolved as **URL parameter → HTTP header → configured value**,
+For the connection fields below, the value is resolved as **URL parameter → HTTP header → configured value**,
 so one exporter instance can be reused as a generic proxy in front of many brokers:
 
 | URL parameter | HTTP header                 | Overrides            |
@@ -122,6 +122,10 @@ so one exporter instance can be reused as a generic proxy in front of many broke
 | `scrapeURI`   | `x-solace-broker-scrapeuri` | Broker SEMP base URI |
 | `timeout`     | `x-solace-broker-timeout`   | Per-request timeout (e.g. `10s`) |
 | `secretBackend` | `x-solace-secret-backend` | `none` to skip vault resolution (plain text) |
+| `isHWBroker`  | `x-solace-broker-ishwbroker` | Broker type (`true`/`false`), gating hardware-only targets |
+
+These overrides do not apply to endpoints served from an async prefetch cache (`prefetchInterval`), which scrape on a
+timer with no request in scope.
 
 ## Configuration
 

--- a/cmd/solace-prometheus-exporter/main.go
+++ b/cmd/solace-prometheus-exporter/main.go
@@ -10,6 +10,7 @@ import (
 	"solace_exporter/internal/exporter"
 	"solace_exporter/internal/secret"
 	"solace_exporter/internal/web"
+	"strconv"
 	"strings"
 	"time"
 
@@ -224,9 +225,9 @@ func parseDataSources(form url.Values, logger *slog.Logger) []exporter.DataSourc
 	return dataSource
 }
 
-// resolveRequestConfig returns a per-request copy of conf with credentials, scrape URI and timeout overridden
-// from the request (form param, then x-solace-broker-* header, else the base Config value); conf itself is never
-// mutated. Username/password are resolved through resolver (skip via secretBackend=none), bounded by r.Context() and secretResolveRequestTimeout.
+// resolveRequestConfig returns a per-request copy of conf with credentials, scrape URI, timeout and broker type
+// overridden from the request (form param, then x-solace-broker-* header, else the base Config value); conf itself is
+// never mutated. Username/password are resolved through resolver (skip via secretBackend=none), bounded by r.Context() and secretResolveRequestTimeout.
 func resolveRequestConfig(r *http.Request, conf *exporter.Config, resolver *secret.Resolver, logger *slog.Logger) (*exporter.Config, error) {
 	reqConf := conf.Clone()
 
@@ -242,6 +243,17 @@ func resolveRequestConfig(r *http.Request, conf *exporter.Config, resolver *secr
 			logger.Error("Per HTTP given timeout must be positive; keeping configured timeout", "timeout", timeout)
 		default:
 			reqConf.Timeout = parsed
+		}
+	}
+
+	if isHWBroker := firstNonEmpty(r.FormValue("isHWBroker"), r.FormValue("ishwbroker"), r.Header.Get("x-solace-broker-ishwbroker")); isHWBroker != "" {
+		parsed, err := strconv.ParseBool(isHWBroker)
+		if err != nil {
+			// Keep the configured value: defaulting to false would silently gate off hardware-only scrape targets
+			// and report them as scrape errors.
+			logger.Error("Per HTTP given isHWBroker parameter is not valid", "err", err, "isHWBroker", isHWBroker)
+		} else {
+			reqConf.IsHWBroker = parsed
 		}
 	}
 

--- a/cmd/solace-prometheus-exporter/main_test.go
+++ b/cmd/solace-prometheus-exporter/main_test.go
@@ -18,14 +18,15 @@ func TestResolveRequestConfig(t *testing.T) {
 	resolver := newTestResolver(t)
 
 	tests := []struct {
-		name              string
-		queryParams       map[string]string
-		headers           map[string]string
-		base              exporter.Config
-		expectedUsername  string
-		expectedPassword  string
-		expectedScrapeURI string
-		expectedTimeout   time.Duration
+		name               string
+		queryParams        map[string]string
+		headers            map[string]string
+		base               exporter.Config
+		expectedUsername   string
+		expectedPassword   string
+		expectedScrapeURI  string
+		expectedTimeout    time.Duration
+		expectedIsHWBroker bool
 	}{
 		{
 			name: "Header override",
@@ -118,6 +119,68 @@ func TestResolveRequestConfig(t *testing.T) {
 			expectedScrapeURI: "http://conf-uri",
 			expectedTimeout:   5 * time.Second,
 		},
+		{
+			name:               "isHWBroker param opens hardware-only targets",
+			queryParams:        map[string]string{"isHWBroker": "true"},
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: true,
+		},
+		{
+			// Header casing does not matter, so the all-lowercase param spelling must work too.
+			name:               "lowercase ishwbroker param alias opens hardware-only targets",
+			queryParams:        map[string]string{"ishwbroker": "true"},
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: true,
+		},
+		{
+			name:               "isHWBroker header opens hardware-only targets",
+			headers:            map[string]string{"x-solace-broker-ishwbroker": "true"},
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: true,
+		},
+		{
+			// The override must work in both directions, so one exporter configured for appliances can also scrape
+			// software brokers.
+			name:               "isHWBroker param can turn a hardware base off",
+			queryParams:        map[string]string{"isHWBroker": "false"},
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second, IsHWBroker: true},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: false,
+		},
+		{
+			name:               "invalid isHWBroker keeps configured value",
+			queryParams:        map[string]string{"isHWBroker": "not-a-bool"},
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second, IsHWBroker: true},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: true,
+		},
+		{
+			name:               "absent isHWBroker falls back to config",
+			base:               exporter.Config{Username: "conf-user", Password: "conf-pass", ScrapeURI: "http://conf-uri", Timeout: 5 * time.Second, IsHWBroker: true},
+			expectedUsername:   "conf-user",
+			expectedPassword:   "conf-pass",
+			expectedScrapeURI:  "http://conf-uri",
+			expectedTimeout:    5 * time.Second,
+			expectedIsHWBroker: true,
+		},
 	}
 
 	for i := range tests {
@@ -153,19 +216,25 @@ func TestResolveRequestConfig(t *testing.T) {
 			if reqConf.Timeout != tt.expectedTimeout {
 				t.Errorf("Timeout: expected %v, got %v", tt.expectedTimeout, reqConf.Timeout)
 			}
+			if reqConf.IsHWBroker != tt.expectedIsHWBroker {
+				t.Errorf("IsHWBroker: expected %v, got %v", tt.expectedIsHWBroker, reqConf.IsHWBroker)
+			}
 
 			// The shared base Config must NOT be mutated by request resolution.
 			if base.Username != tt.base.Username || base.Password != tt.base.Password ||
-				base.ScrapeURI != tt.base.ScrapeURI || base.Timeout != tt.base.Timeout {
+				base.ScrapeURI != tt.base.ScrapeURI || base.Timeout != tt.base.Timeout ||
+				base.IsHWBroker != tt.base.IsHWBroker {
 				t.Errorf("base Config was mutated: got %+v, want %+v",
 					struct {
 						U, P, S string
 						T       time.Duration
-					}{base.Username, base.Password, base.ScrapeURI, base.Timeout},
+						H       bool
+					}{base.Username, base.Password, base.ScrapeURI, base.Timeout, base.IsHWBroker},
 					struct {
 						U, P, S string
 						T       time.Duration
-					}{tt.base.Username, tt.base.Password, tt.base.ScrapeURI, tt.base.Timeout})
+						H       bool
+					}{tt.base.Username, tt.base.Password, tt.base.ScrapeURI, tt.base.Timeout, tt.base.IsHWBroker})
 			}
 		})
 	}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -40,7 +40,8 @@ The Solace Prometheus Exporter can be configured using four methods (in order of
 
 > **Note:** Config file keys in the `[solace]` section are matched case-insensitively, so historically diverging
 > spellings remain interchangeable — for example `scrapeURI` and `scrapeUri` (and the `scrapeURI`/`scrapeUri` URL
-> parameter) all resolve to the same setting.
+> parameter) all resolve to the same setting. The `isHWBroker` URL parameter likewise accepts the all-lowercase
+> `ishwbroker` spelling, matching its case-insensitive header.
 
 ## 🧩 Modular Endpoints
 The `/solace` endpoint allows you to granularly define which metrics to collect using HTTP GET parameters. This is the recommended way to optimize performance and reduce broker load.
@@ -55,8 +56,14 @@ You can overwrite the broker configuration dynamically for each request. This is
 | `scrapeURI`   | `x-solace-broker-scrapeuri` | URI of the Solace broker                                                                        |
 | `timeout`     | `x-solace-broker-timeout`   | Timeout for the request (e.g. `10s`)                                                            |
 | `secretBackend` | `x-solace-secret-backend` | *(unset)* uses the global `SECRET_BACKEND`; `none` skips vault resolution (plain text).         |   
+| `isHWBroker`  | `x-solace-broker-ishwbroker` | `true`/`false`. Overrides the `isHWBroker` setting, so a single exporter can scrape both appliances and software brokers. An unparsable value keeps the configured setting. |
 
 **Priority**: URL Parameter > HTTP Header > Configuration File / Environment Variable.
+
+> **Note:** These per-request overrides apply to the `/solace` endpoint and to config-file endpoints served
+> synchronously. They have no effect when `prefetchInterval` is set: prefetching scrapes on a timer with no request in
+> scope, so those endpoints always use the broker configuration from the config file. Mixing broker types behind one
+> exporter therefore requires the synchronous path.
 
 ### Parameter Syntax
 Each parameter key must be a **scrape target** (see list below) prefixed by `m.`. The value consists of **2–3 parts**, delimited by a pipe `|`:


### PR DESCRIPTION
## Allow isHWBroker to be set per request

`isHWBroker` was startup-only, so monitoring appliances and software brokers
required two exporter instances — even though broker URI, credentials and
timeout are already per-request overridable. This lets one exporter front both.

Resolved in `resolveRequestConfig` alongside the existing overrides:

| URL param | HTTP header | Precedence |
|---|---|---|
| `isHWBroker` | `x-solace-broker-ishwbroker` | param → header → `SOLACE_IS_HW_BROKER` → ini → `false` |
