### PR TITLE
Add FOSSA SCA scanning and dependency manifest registration [skip ci]

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,25 @@
+version: 3
+
+project:
+  locator: solacecommunity_solace-prometheus-exporter
+  id: solacecommunity_solace-prometheus-exporter
+  name: solace-prometheus-exporter
+  teams: []
+  labels:
+    - go
+
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+
+telemetry:
+  scope: full

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,8 @@
+{
+  "sca_scanning": {
+    "fossa": {
+      "policy": { "mode": "REPORT" },
+      "vulnerability": { "mode": "REPORT" }
+    }
+  }
+}

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,58 @@
+name: SCA Scan
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  actions: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  sca_scan:
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    # The manifest records what landed on the default branch, so it must never
+    # be written from a PR run -- the scan still runs, the write does not.
+    if: >-
+      needs.sca_scan.result == 'success'
+      && github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.MANIFEST_AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "cto",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,9 +25,15 @@ jobs:
     needs: sca_scan
     # The manifest records what landed on the default branch, so it must never
     # be written from a PR run -- the scan still runs, the write does not.
+    #
+    # workflow_dispatch is allowed so this repo can be merged with a skip-ci
+    # commit (which suppresses every workflow on that push, including the
+    # release/publish one) and then have the scan and manifest write triggered
+    # by hand. The default-branch check still applies, so dispatching against
+    # any other ref scans without writing.
     if: >-
       needs.sca_scan.result == 'success'
-      && github.event_name == 'push'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -53,6 +53,7 @@ jobs:
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",
-                "version": "${{ github.ref_name }}"
+                "version": "${{ github.ref_name }}",
+                "image_tag": "latest"
               }
             }


### PR DESCRIPTION
Adds FOSSA SCA scanning on `master` plus a build-manifest registration step, so this repo is covered by our automated dependency vulnerability tracking.

### What this adds

| File | Purpose |
|---|---|
| `.fossa.yml` | FOSSA project config |
| `.github/workflow-config.json` | FOSSA policy/vulnerability both in `REPORT` mode — this gates nothing |
| `.github/workflows/sca-scan-and-guard.yml` | Scan on PR + push to `master`; manifest write on push only |

### Non-blocking by design

`REPORT` mode means FOSSA findings are recorded, not enforced. This PR cannot start failing anyone else's builds.

The `update_manifest` job is guarded on `github.event_name == 'push' && github.ref_name == github.event.repository.default_branch`, so it does not run on pull requests — only the scan does.

### Pattern notes

Mirrors the equivalent setup already merged and passing across our other public repos. One thing carried over deliberately: **no scan matrix**. `fossa.only_path` scopes what is scanned, but the project id comes from `--project`, so matrix entries all upload into one project and overwrite each other, while the manifest emits one row per entry — producing registrations that point at FOSSA projects which never exist. A root scan resolves every ecosystem in one pass. One repo, one FOSSA project, one manifest row.
